### PR TITLE
Expose contract parameters, tweak dev and production settings.

### DIFF
--- a/blockchain/contracts/Forum.sol
+++ b/blockchain/contracts/Forum.sol
@@ -16,23 +16,18 @@ contract Forum {
     error InsufficientCredits(uint available, int required);
     error TimestampOrderInvalid(uint fromTimestamp, uint toTimestamp);
 
-    // Maximum length (in chars) of a statement
-    uint public constant MAX_STATEMENT_LENGTH = 120;
+    // Maximum length (in bytes) of a statement
+    uint public immutable maxStatementLength;
     // Amount of credits a user is credited each "step"
-    uint public constant USER_CREDIT_ALLOWANCE_PER_STEP = 25;
-    // Starting credits for a new user, one week of allowance
-    uint public constant USER_STARTING_CREDITS = 1050;
-    // We only track this many statements for ranking purposes
-    uint public constant MAX_RANKED_STATEMENTS = 1000;
+    uint public immutable userCreditAllowancePerStep;
+    // Starting credits for a new user
+    uint public immutable userStartingCredits;
     // Minimum support required for a statement to be ranked
-    int public constant MIN_STATEMENT_SUPPORT_TO_RANK = 2;
-
-    // Configurable max ranked statements (defaults to MAX_RANKED_STATEMENTS)
+    int public immutable minStatementSupportToRank;
+    // We only track this many statements for ranking purposes
     uint public immutable maxRankedStatements;
-
     // Duration of a single decay/credit step in seconds
     uint public immutable stepDurationSeconds;
-
     // Minimum seconds between StatementEngaged events for the same statement
     uint public immutable engagementWindowSeconds;
 
@@ -108,15 +103,21 @@ contract Forum {
         string memory _nationality,
         uint _maxRankedStatements,
         uint _stepDurationSeconds,
-        uint _engagementWindowSeconds
+        uint _engagementWindowSeconds,
+        uint _maxStatementLength,
+        uint _userCreditAllowancePerStep,
+        uint _userStartingCredits,
+        int _minStatementSupportToRank
     ) {
         ourVoiceRegistry = _ourVoiceRegistry;
         nationality = _nationality;
-        maxRankedStatements = _maxRankedStatements == 0
-            ? MAX_RANKED_STATEMENTS
-            : _maxRankedStatements;
+        maxRankedStatements = _maxRankedStatements;
         stepDurationSeconds = _stepDurationSeconds;
         engagementWindowSeconds = _engagementWindowSeconds;
+        maxStatementLength = _maxStatementLength;
+        userCreditAllowancePerStep = _userCreditAllowancePerStep;
+        userStartingCredits = _userStartingCredits;
+        minStatementSupportToRank = _minStatementSupportToRank;
     }
 
     function _resolveStatement(
@@ -205,7 +206,7 @@ contract Forum {
             _getCurrentSupportValue(
                 statements[statementRankings[rankedCount - 1]].support
             ) <
-            MIN_STATEMENT_SUPPORT_TO_RANK
+            minStatementSupportToRank
         ) {
             rankedCount -= 1;
             _setStatementRank(statementRankings[rankedCount], -1);
@@ -214,7 +215,7 @@ contract Forum {
 
     function _getRankingThreshold() internal view returns (int) {
         if (rankedCount < maxRankedStatements) {
-            return MIN_STATEMENT_SUPPORT_TO_RANK;
+            return minStatementSupportToRank;
         }
         uint _lowestRankedStatementId = statementRankings[rankedCount - 1];
         return
@@ -300,10 +301,10 @@ contract Forum {
     }
 
     function addStatement(string calldata _statementText) external onlyMembers {
-        if (bytes(_statementText).length > MAX_STATEMENT_LENGTH)
+        if (bytes(_statementText).length > maxStatementLength)
             revert StatementTooLong(
                 bytes(_statementText).length,
-                MAX_STATEMENT_LENGTH
+                maxStatementLength
             );
 
         // Ensure the statement is not empty
@@ -400,7 +401,7 @@ contract Forum {
         UserBalance memory _balance
     ) internal view returns (uint) {
         if (_balance.lastUpdated == 0) {
-            _balance.credits = USER_STARTING_CREDITS;
+            _balance.credits = userStartingCredits;
             _balance.lastUpdated = ourVoiceRegistry
                 .getUserRegistration(msg.sender)
                 .registrationTimestamp;
@@ -410,8 +411,7 @@ contract Forum {
             _balance.lastUpdated,
             block.timestamp
         );
-        return
-            _balance.credits + (_elapsedSteps * USER_CREDIT_ALLOWANCE_PER_STEP);
+        return _balance.credits + (_elapsedSteps * userCreditAllowancePerStep);
     }
 
     function _updateUserBalanceToBeCurrent(

--- a/blockchain/contracts/Forum.t.sol
+++ b/blockchain/contracts/Forum.t.sol
@@ -16,14 +16,22 @@ contract ForumHarness is Forum {
         string memory _nationality,
         uint _maxRankedStatements,
         uint _stepDurationSeconds,
-        uint _engagementWindowSeconds
+        uint _engagementWindowSeconds,
+        uint _maxStatementLength,
+        uint _userCreditAllowancePerStep,
+        uint _userStartingCredits,
+        int _minStatementSupportToRank
     )
         Forum(
             _ourVoiceRegistry,
             _nationality,
             _maxRankedStatements,
             _stepDurationSeconds,
-            _engagementWindowSeconds
+            _engagementWindowSeconds,
+            _maxStatementLength,
+            _userCreditAllowancePerStep,
+            _userStartingCredits,
+            _minStatementSupportToRank
         )
     {}
 
@@ -56,7 +64,7 @@ contract ForumTest is Test {
     function setUp() public {
         vm.warp(MOCK_TEST_TIMESTAMP);
         mockRegistry = new MockOurVoiceRegistry();
-        forum = new ForumHarness(mockRegistry, "", 3, 10, 60);
+        forum = new ForumHarness(mockRegistry, "", 3, 10, 60, 120, 25, 1000, 2);
     }
 
     modifier registeredMember() {
@@ -144,8 +152,11 @@ contract ForumTest is Test {
 
     function testInitialUserBalance() external registeredMember {
         uint balance = forum.getUserBalance();
-        // TODO: fix my constants management
-        assertEq(balance, 1050, "Initial user balance should be 1050 credits");
+        assertEq(
+            balance,
+            1000,
+            "Initial user balance should match userStartingCredits"
+        );
     }
 
     function testUserBalanceAllowance() external registeredMember {

--- a/blockchain/ignition/config/deployments.ts
+++ b/blockchain/ignition/config/deployments.ts
@@ -11,6 +11,11 @@ type MockedDeploymentConfig = {
   forums: string[];
   stepDurationSeconds: number;
   engagementWindowSeconds: number;
+  maxRankedStatements: number;
+  minStatementSupportToRank: number;
+  maxStatementLength: number;
+  userCreditAllowancePerStep: number;
+  userStartingCredits: number;
 };
 
 type ProductionDeploymentConfig = {
@@ -18,6 +23,11 @@ type ProductionDeploymentConfig = {
   forums: string[];
   stepDurationSeconds: number;
   engagementWindowSeconds: number;
+  maxRankedStatements: number;
+  minStatementSupportToRank: number;
+  maxStatementLength: number;
+  userCreditAllowancePerStep: number;
+  userStartingCredits: number;
   parametersFile: string;
 };
 
@@ -28,24 +38,39 @@ const deploymentConfigs: Record<string, DeploymentConfig> = {
   default: {
     mode: "mocked",
     forums: ["global", "USA", "CAN"],
-    stepDurationSeconds: 10,
-    engagementWindowSeconds: 300, // Short engagement window for testing
+    stepDurationSeconds: 60,
+    engagementWindowSeconds: 300,
+    maxRankedStatements: 10,
+    minStatementSupportToRank: 3,
+    maxStatementLength: 120,
+    userCreditAllowancePerStep: 25,
+    userStartingCredits: 1000,
   },
 
   /** Docker Compose Hardhat node with mock data. */
   compose_hardhat: {
     mode: "mocked",
     forums: ["global", "USA", "CAN"],
-    stepDurationSeconds: 10,
-    engagementWindowSeconds: 300, // Short engagement window for testing
+    stepDurationSeconds: 60,
+    engagementWindowSeconds: 300,
+    maxRankedStatements: 10,
+    minStatementSupportToRank: 3,
+    maxStatementLength: 120,
+    userCreditAllowancePerStep: 25,
+    userStartingCredits: 1000,
   },
 
   /** Local Sepolia fork with real OurVoiceRegistry (dev mode). */
   local_sepolia_fork: {
     mode: "production",
     forums: ["global", "USA", "CAN"],
-    stepDurationSeconds: 10,
-    engagementWindowSeconds: 86400,
+    stepDurationSeconds: 60,
+    engagementWindowSeconds: 300,
+    maxRankedStatements: 10,
+    minStatementSupportToRank: 3,
+    maxStatementLength: 120,
+    userCreditAllowancePerStep: 25,
+    userStartingCredits: 1000,
     parametersFile: "local-fork.json",
   },
 
@@ -55,6 +80,11 @@ const deploymentConfigs: Record<string, DeploymentConfig> = {
     forums: ["global", "USA", "CAN"],
     stepDurationSeconds: 14400,
     engagementWindowSeconds: 86400,
+    maxRankedStatements: 1000,
+    minStatementSupportToRank: 10,
+    maxStatementLength: 120,
+    userCreditAllowancePerStep: 25,
+    userStartingCredits: 1000,
     parametersFile: "sepolia.json",
   },
 };

--- a/blockchain/ignition/modules/ForumMockedRegistry.ts
+++ b/blockchain/ignition/modules/ForumMockedRegistry.ts
@@ -134,6 +134,11 @@ export function createForumMockedModule(
   forumNames: string[],
   stepDurationSeconds: number,
   engagementWindowSeconds: number,
+  maxRankedStatements: number,
+  minStatementSupportToRank: number,
+  maxStatementLength: number,
+  userCreditAllowancePerStep: number,
+  userStartingCredits: number,
 ) {
   return buildModule("ForumMockedRegistryModule", (m) => {
     const address1 = m.getAccount(0);
@@ -159,7 +164,12 @@ export function createForumMockedModule(
       id: "register4",
     });
 
-    const { forums } = deployForums(m, mockedZKRegistry, forumNames, stepDurationSeconds, engagementWindowSeconds);
+    const { forums } = deployForums(
+      m, mockedZKRegistry, forumNames,
+      stepDurationSeconds, engagementWindowSeconds,
+      maxRankedStatements, minStatementSupportToRank,
+      maxStatementLength, userCreditAllowancePerStep, userStartingCredits,
+    );
 
     // Track statement futures per forum so support calls can depend on them
     const statementFutures: Record<string, ReturnType<typeof m.call>[]> = {};

--- a/blockchain/ignition/modules/ForumProduction.ts
+++ b/blockchain/ignition/modules/ForumProduction.ts
@@ -23,6 +23,11 @@ export function createForumProductionModule(
   forumNames: string[],
   stepDurationSeconds: number,
   engagementWindowSeconds: number,
+  maxRankedStatements: number,
+  minStatementSupportToRank: number,
+  maxStatementLength: number,
+  userCreditAllowancePerStep: number,
+  userStartingCredits: number,
 ) {
   return buildModule("ForumProductionModule", (m) => {
     const verifierAddress = m.getParameter<string>("verifierAddress");
@@ -42,7 +47,12 @@ export function createForumProductionModule(
       devMode,
     ]);
 
-    const { forums } = deployForums(m, registry, forumNames, stepDurationSeconds, engagementWindowSeconds);
+    const { forums } = deployForums(
+      m, registry, forumNames,
+      stepDurationSeconds, engagementWindowSeconds,
+      maxRankedStatements, minStatementSupportToRank,
+      maxStatementLength, userCreditAllowancePerStep, userStartingCredits,
+    );
 
     return { registry, ...forums };
   });

--- a/blockchain/ignition/modules/helpers/deployForums.ts
+++ b/blockchain/ignition/modules/helpers/deployForums.ts
@@ -7,12 +7,17 @@ import type {
 /**
  * Shared helper that deploys a set of Forum contracts pointing at the given registry.
  *
- * @param m                       - The Ignition module builder.
- * @param registry                - A Future resolving to the OurVoiceRegistry (or mock) contract.
- * @param forumNames              - The list of forum identifiers to deploy (e.g. ["global", "USA"]).
- *                                  "global" is special-cased to pass an empty nationality string.
- * @param stepDurationSeconds     - The duration (in seconds) of a single decay/credit step.
- * @param engagementWindowSeconds - Minimum seconds between StatementEngaged events per statement.
+ * @param m                          - The Ignition module builder.
+ * @param registry                   - A Future resolving to the OurVoiceRegistry (or mock) contract.
+ * @param forumNames                 - The list of forum identifiers to deploy (e.g. ["global", "USA"]).
+ *                                     "global" is special-cased to pass an empty nationality string.
+ * @param stepDurationSeconds        - The duration (in seconds) of a single decay/credit step.
+ * @param engagementWindowSeconds    - Minimum seconds between StatementEngaged events per statement.
+ * @param maxRankedStatements        - Maximum number of ranked statements per forum.
+ * @param minStatementSupportToRank  - Minimum support value for a statement to enter rankings.
+ * @param maxStatementLength         - Maximum byte length of a statement.
+ * @param userCreditAllowancePerStep - Credits granted per step.
+ * @param userStartingCredits        - Credits for newly registered users.
  * @returns A record mapping each forum name to its deployed Forum contract Future.
  */
 export function deployForums(
@@ -21,6 +26,11 @@ export function deployForums(
   forumNames: string[],
   stepDurationSeconds: number,
   engagementWindowSeconds: number,
+  maxRankedStatements: number,
+  minStatementSupportToRank: number,
+  maxStatementLength: number,
+  userCreditAllowancePerStep: number,
+  userStartingCredits: number,
 ): {
   forums: Record<string, NamedArtifactContractDeploymentFuture<"Forum">>;
 } {
@@ -29,7 +39,17 @@ export function deployForums(
       forum,
       m.contract(
         "Forum",
-        [registry, forum === "global" ? "" : forum, 0, stepDurationSeconds, engagementWindowSeconds],
+        [
+          registry,
+          forum === "global" ? "" : forum,
+          maxRankedStatements,
+          stepDurationSeconds,
+          engagementWindowSeconds,
+          maxStatementLength,
+          userCreditAllowancePerStep,
+          userStartingCredits,
+          minStatementSupportToRank,
+        ],
         { id: `Forum_${forum}` },
       ),
     ]),

--- a/blockchain/scripts/deploy.ts
+++ b/blockchain/scripts/deploy.ts
@@ -27,11 +27,19 @@ async function main() {
     const { networkHelpers } = connection;
     await networkHelpers.time.increaseTo(Math.floor(Date.now() / 1000) + 1);
 
-    const module = createForumMockedModule(config.forums, config.stepDurationSeconds, config.engagementWindowSeconds);
+    const module = createForumMockedModule(
+      config.forums, config.stepDurationSeconds, config.engagementWindowSeconds,
+      config.maxRankedStatements, config.minStatementSupportToRank,
+      config.maxStatementLength, config.userCreditAllowancePerStep, config.userStartingCredits,
+    );
     const deployResult = await ignition.deploy(module);
     ({ registry, ...forums } = deployResult);
   } else {
-    const module = createForumProductionModule(config.forums, config.stepDurationSeconds, config.engagementWindowSeconds);
+    const module = createForumProductionModule(
+      config.forums, config.stepDurationSeconds, config.engagementWindowSeconds,
+      config.maxRankedStatements, config.minStatementSupportToRank,
+      config.maxStatementLength, config.userCreditAllowancePerStep, config.userStartingCredits,
+    );
     const parametersPath = path.resolve(
       import.meta.dirname,
       "../ignition/parameters",


### PR DESCRIPTION
This pull request refactors the `Forum` smart contract and its deployment scripts to make key forum parameters configurable at deployment time, rather than hardcoded as constants. This improves flexibility for different environments and use cases, allowing parameters such as statement length, credit allowances, and ranking thresholds to be easily set per deployment. The changes also update the deployment scripts, helper functions, and tests to support the new constructor arguments.

The most important changes are:

**Smart Contract Parameterization:**

* Replaced several `constant` values in `Forum.sol` (such as `MAX_STATEMENT_LENGTH`, `USER_CREDIT_ALLOWANCE_PER_STEP`, `USER_STARTING_CREDITS`, `MIN_STATEMENT_SUPPORT_TO_RANK`, and `MAX_RANKED_STATEMENTS`) with `immutable` variables set via the constructor, making these parameters configurable at deployment.
* Updated all internal references in `Forum.sol` to use the new `immutable` variables instead of the previous constants, ensuring the contract logic uses the deployment-time values. [[1]](diffhunk://#diff-da6fc019dd40f7410e5d163ec1fb95684a2b167bd489690890c227b002fa9d57L208-R209) [[2]](diffhunk://#diff-da6fc019dd40f7410e5d163ec1fb95684a2b167bd489690890c227b002fa9d57L217-R218) [[3]](diffhunk://#diff-da6fc019dd40f7410e5d163ec1fb95684a2b167bd489690890c227b002fa9d57L303-R307) [[4]](diffhunk://#diff-da6fc019dd40f7410e5d163ec1fb95684a2b167bd489690890c227b002fa9d57L403-R404) [[5]](diffhunk://#diff-da6fc019dd40f7410e5d163ec1fb95684a2b167bd489690890c227b002fa9d57L413-R414)

**Deployment and Helper Script Updates:**

* Modified deployment scripts and helpers (`deployForums.ts`, `ForumMockedRegistry.ts`, `ForumProduction.ts`, and `deploy.ts`) to accept and pass the new configuration parameters when deploying `Forum` contracts. [[1]](diffhunk://#diff-774bf19d4bfe2b5c4e6b2b0beff37301f7d03a425c479a7efbfd8c210328a240R16-R20) [[2]](diffhunk://#diff-774bf19d4bfe2b5c4e6b2b0beff37301f7d03a425c479a7efbfd8c210328a240R29-R33) [[3]](diffhunk://#diff-774bf19d4bfe2b5c4e6b2b0beff37301f7d03a425c479a7efbfd8c210328a240L32-R52) [[4]](diffhunk://#diff-de9e3afeb35266dadbf9b34c705171a9f6a894440f4afc76c5090e564384f1dcR137-R141) [[5]](diffhunk://#diff-de9e3afeb35266dadbf9b34c705171a9f6a894440f4afc76c5090e564384f1dcL162-R172) [[6]](diffhunk://#diff-50365c30db997614d9aa8af600d291971b7af14bed29bcc21bfdb04538ee2334R26-R30) [[7]](diffhunk://#diff-50365c30db997614d9aa8af600d291971b7af14bed29bcc21bfdb04538ee2334L45-R55) [[8]](diffhunk://#diff-84081a91f8f947bbec74fc7ccf5a1600da50c26255769c871170c164c3eaef36L30-R42)
* Updated deployment configuration files to include the new parameters for each environment, ensuring they are set appropriately for production, development, and test deployments. [[1]](diffhunk://#diff-73b453a796991e394ee8b27d1728a3cb519b1b634d412ad21173cd05ab538083R14-R30) [[2]](diffhunk://#diff-73b453a796991e394ee8b27d1728a3cb519b1b634d412ad21173cd05ab538083L31-R73) [[3]](diffhunk://#diff-73b453a796991e394ee8b27d1728a3cb519b1b634d412ad21173cd05ab538083R83-R87)

**Test Adjustments:**

* Updated the test harness and tests in `Forum.t.sol` to use the new constructor arguments and to assert against the configured values rather than hardcoded constants. [[1]](diffhunk://#diff-af9e60e89760bf1f7cd7c3c9f5db397041e21c95b30d332b216c030fd7152421L19-R34) [[2]](diffhunk://#diff-af9e60e89760bf1f7cd7c3c9f5db397041e21c95b30d332b216c030fd7152421L59-R67) [[3]](diffhunk://#diff-af9e60e89760bf1f7cd7c3c9f5db397041e21c95b30d332b216c030fd7152421L147-R159)