### PR TITLE
Implement operation batch with Multicall

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "npx hardhat compile",
+      "npx hardhat test"
+    ]
+  }
+}

--- a/blockchain/contracts/Forum.sol
+++ b/blockchain/contracts/Forum.sol
@@ -16,6 +16,7 @@ contract Forum is Multicall {
     error UserNotRegistered(address user);
     error InsufficientCredits(uint available, int required);
     error TimestampOrderInvalid(uint fromTimestamp, uint toTimestamp);
+    error StaleStep(uint expected, uint actual);
 
     // Maximum length (in bytes) of a statement
     uint public immutable maxStatementLength;
@@ -527,10 +528,13 @@ contract Forum is Multicall {
         }
     }
 
-    function _adjustSupport(
-        bytes32 _userId,
-        SupportAdjustment[] memory _supportAdjustments
-    ) internal {
+    function adjustSupport(
+        SupportAdjustment[] calldata _supportAdjustments
+    ) external onlyMembers {
+        if (!ourVoiceRegistry.isRegistered(msg.sender))
+            revert UserNotRegistered(msg.sender);
+        bytes32 _userId = ourVoiceRegistry.getUserIdentifier(msg.sender);
+
         UserBalance storage _userBalance = userCredits[_userId];
         _updateUserBalanceToBeCurrent(_userBalance);
 
@@ -583,35 +587,12 @@ contract Forum is Multicall {
         );
     }
 
-    function adjustSupport(
-        SupportAdjustment[] calldata _supportAdjustments
-    ) external onlyMembers {
-        if (!ourVoiceRegistry.isRegistered(msg.sender))
-            revert UserNotRegistered(msg.sender);
-        bytes32 _userId = ourVoiceRegistry.getUserIdentifier(msg.sender);
-        _adjustSupport(_userId, _supportAdjustments);
-    }
-
-    function clearSupport(uint[] calldata _statementIds) external onlyMembers {
-        if (!ourVoiceRegistry.isRegistered(msg.sender))
-            revert UserNotRegistered(msg.sender);
-        bytes32 _userId = ourVoiceRegistry.getUserIdentifier(msg.sender);
-
-        SupportAdjustment[] memory _adjustments = new SupportAdjustment[](
-            _statementIds.length
-        );
-        for (uint i = 0; i < _statementIds.length; i++) {
-            if (_statementIds[i] >= statementCount)
-                revert InvalidStatementId(_statementIds[i]);
-            int _currentSupport = _getCurrentSupportValue(
-                userSupportMap[_userId][_statementIds[i]]
-            );
-            _adjustments[i] = SupportAdjustment({
-                statementId: _statementIds[i],
-                value: -_currentSupport
-            });
-        }
-        _adjustSupport(_userId, _adjustments);
+    /// @notice Reverts if the current decay step does not match the expected value.
+    /// @dev Intended for use via multicall to guard against decay drift.
+    function requireStep(uint _expectedStep) external view {
+        uint actualStep = block.timestamp / stepDurationSeconds;
+        if (actualStep != _expectedStep)
+            revert StaleStep(_expectedStep, actualStep);
     }
 
     fallback() external {}

--- a/blockchain/contracts/Forum.sol
+++ b/blockchain/contracts/Forum.sol
@@ -4,8 +4,9 @@ pragma solidity ^0.8.28;
 import "./IOurVoiceRegistry.sol";
 import "./StringUtils.sol";
 import "./DecayUtils.sol";
+import "@openzeppelin/contracts/utils/Multicall.sol";
 
-contract Forum {
+contract Forum is Multicall {
     // Custom errors
     error NotMember();
     error RankOutOfBounds(uint rank, uint rankedCount);
@@ -296,11 +297,25 @@ contract Forum {
             _rank += 1;
         }
 
+        // If the statement's support has fallen below the ranking threshold,
+        // unrank it and compact the array.
+        if (
+            _getCurrentSupportValue(statement.support) <
+            minStatementSupportToRank
+        ) {
+            rankedCount -= 1;
+            _setStatementRank(_statementId, -1);
+            return;
+        }
+
         statementRankings[_rank] = _statementId;
         _setStatementRank(_statementId, int(_rank));
     }
 
-    function addStatement(string calldata _statementText) external onlyMembers {
+    function addStatement(
+        string calldata _statementText,
+        int _initialSupport
+    ) external onlyMembers {
         if (bytes(_statementText).length > maxStatementLength)
             revert StatementTooLong(
                 bytes(_statementText).length,
@@ -319,6 +334,29 @@ contract Forum {
             peakRank: -1,
             lastEngagementEventTimestamp: 0
         });
+
+        if (_initialSupport != 0) {
+            if (!ourVoiceRegistry.isRegistered(msg.sender))
+                revert UserNotRegistered(msg.sender);
+            bytes32 _userId = ourVoiceRegistry.getUserIdentifier(msg.sender);
+
+            // Apply initial support to statement and user support map
+            statements[statementCount].support.value = _initialSupport;
+            userSupportMap[_userId][statementCount] = Support({
+                value: _initialSupport,
+                lastUpdated: block.timestamp
+            });
+            _updateUserSupportedStatements(_userId, statementCount);
+
+            // Charge credits (old cost is 0 since this is a new statement)
+            uint _cost = _costOfUserSupport(_initialSupport);
+            UserBalance storage _userBalance = userCredits[_userId];
+            _updateUserBalanceToBeCurrent(_userBalance);
+            if (_userBalance.credits < _cost)
+                revert InsufficientCredits(_userBalance.credits, int(_cost));
+            _userBalance.credits -= _cost;
+        }
+
         _updateStatementRanking(statementCount);
         emit StatementAdded(statementCount, _statementText);
         statementCount++;
@@ -489,13 +527,10 @@ contract Forum {
         }
     }
 
-    function adjustSupport(
-        SupportAdjustment[] calldata _supportAdjustments
-    ) external onlyMembers {
-        if (!ourVoiceRegistry.isRegistered(msg.sender))
-            revert UserNotRegistered(msg.sender);
-        bytes32 _userId = ourVoiceRegistry.getUserIdentifier(msg.sender);
-
+    function _adjustSupport(
+        bytes32 _userId,
+        SupportAdjustment[] memory _supportAdjustments
+    ) internal {
         UserBalance storage _userBalance = userCredits[_userId];
         _updateUserBalanceToBeCurrent(_userBalance);
 
@@ -546,6 +581,37 @@ contract Forum {
         _userBalance.credits = uint(
             int(_userBalance.credits) - _totalCostChange
         );
+    }
+
+    function adjustSupport(
+        SupportAdjustment[] calldata _supportAdjustments
+    ) external onlyMembers {
+        if (!ourVoiceRegistry.isRegistered(msg.sender))
+            revert UserNotRegistered(msg.sender);
+        bytes32 _userId = ourVoiceRegistry.getUserIdentifier(msg.sender);
+        _adjustSupport(_userId, _supportAdjustments);
+    }
+
+    function clearSupport(uint[] calldata _statementIds) external onlyMembers {
+        if (!ourVoiceRegistry.isRegistered(msg.sender))
+            revert UserNotRegistered(msg.sender);
+        bytes32 _userId = ourVoiceRegistry.getUserIdentifier(msg.sender);
+
+        SupportAdjustment[] memory _adjustments = new SupportAdjustment[](
+            _statementIds.length
+        );
+        for (uint i = 0; i < _statementIds.length; i++) {
+            if (_statementIds[i] >= statementCount)
+                revert InvalidStatementId(_statementIds[i]);
+            int _currentSupport = _getCurrentSupportValue(
+                userSupportMap[_userId][_statementIds[i]]
+            );
+            _adjustments[i] = SupportAdjustment({
+                statementId: _statementIds[i],
+                value: -_currentSupport
+            });
+        }
+        _adjustSupport(_userId, _adjustments);
     }
 
     fallback() external {}

--- a/blockchain/contracts/Forum.sol
+++ b/blockchain/contracts/Forum.sol
@@ -316,7 +316,7 @@ contract Forum is Multicall {
     function addStatement(
         string calldata _statementText,
         int _initialSupport
-    ) external onlyMembers {
+    ) external onlyMembers returns (uint) {
         if (bytes(_statementText).length > maxStatementLength)
             revert StatementTooLong(
                 bytes(_statementText).length,
@@ -360,7 +360,9 @@ contract Forum is Multicall {
 
         _updateStatementRanking(statementCount);
         emit StatementAdded(statementCount, _statementText);
+        uint _id = statementCount;
         statementCount++;
+        return _id;
     }
 
     function getUserBalance() external view onlyMembers returns (uint) {

--- a/blockchain/contracts/Forum.sol
+++ b/blockchain/contracts/Forum.sol
@@ -589,6 +589,13 @@ contract Forum is Multicall {
         );
     }
 
+    /// @notice Returns the current decay step index (block.timestamp / stepDurationSeconds).
+    /// @dev Read this on-chain immediately before building a multicall with requireStep
+    ///      to avoid StaleStep reverts caused by frontend clock skew.
+    function getCurrentStep() external view returns (uint) {
+        return block.timestamp / stepDurationSeconds;
+    }
+
     /// @notice Reverts if the current decay step does not match the expected value.
     /// @dev Intended for use via multicall to guard against decay drift.
     function requireStep(uint _expectedStep) external view {

--- a/blockchain/contracts/Forum.t.sol
+++ b/blockchain/contracts/Forum.t.sol
@@ -1405,61 +1405,49 @@ contract ForumTest is Test {
         _addStatementSupport(0, 1);
     }
 
-    function testClearSupportResetsSupportAndRefundsCredits()
+    function testRequireStepSucceedsOnCorrectStep() external registeredMember {
+        uint expectedStep = block.timestamp / forum.stepDurationSeconds();
+        // Should not revert
+        forum.requireStep(expectedStep);
+    }
+
+    function testRequireStepRevertsOnWrongStep() external registeredMember {
+        uint expectedStep = block.timestamp / forum.stepDurationSeconds();
+        uint wrongStep = expectedStep + 1;
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Forum.StaleStep.selector,
+                wrongStep,
+                expectedStep
+            )
+        );
+        forum.requireStep(wrongStep);
+    }
+
+    function testRequireStepChangesAfterTimeAdvance()
         external
         registeredMember
     {
-        forum.addStatement("Statement A", 0);
-        forum.addStatement("Statement B", 0);
+        uint stepDuration = forum.stepDurationSeconds();
+        uint stepBefore = block.timestamp / stepDuration;
 
-        _addStatementSupport(0, 5); // Cost: 15
-        _addStatementSupport(1, 3); // Cost: 6
+        // Advance time by one full step
+        vm.warp(block.timestamp + stepDuration);
 
-        uint balanceAfterSupport = forum.getUserBalance();
+        uint stepAfter = block.timestamp / stepDuration;
+        assertEq(stepAfter, stepBefore + 1, "Step should have advanced by 1");
 
-        // Clear support on both statements
-        uint[] memory statementIds = new uint[](2);
-        statementIds[0] = 0;
-        statementIds[1] = 1;
-        forum.clearSupport(statementIds);
-
-        // Support should be zero
-        Forum.Statement memory s0 = _getStatementById(0);
-        Forum.Statement memory s1 = _getStatementById(1);
-        assertEq(s0.support, 0, "Statement 0 support should be 0 after clear");
-        assertEq(s1.support, 0, "Statement 1 support should be 0 after clear");
-
-        // Credits should be fully refunded (15 + 6 = 21)
-        uint finalBalance = forum.getUserBalance();
-        assertEq(
-            finalBalance,
-            balanceAfterSupport + 21,
-            "Credits should be refunded by 21 after clearing support"
+        // Old step should now revert
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Forum.StaleStep.selector,
+                stepBefore,
+                stepAfter
+            )
         );
-    }
+        forum.requireStep(stepBefore);
 
-    function testClearSupportRemovesFromRanking() external registeredMember {
-        forum.addStatement("Statement A", 0);
-        forum.addStatement("Statement B", 0);
-
-        _addStatementSupport(0, 5); // Ranked
-        _addStatementSupport(1, 3); // Ranked
-
-        // Verify both are ranked
-        assertEq(forum.rankedCount(), 2, "Both statements should be ranked");
-
-        // Clear support on statement 0
-        uint[] memory statementIds = new uint[](1);
-        statementIds[0] = 0;
-        forum.clearSupport(statementIds);
-
-        // Statement 0 should be immediately unranked
-        Forum.Statement memory s0 = _getStatementById(0);
-        assertEq(s0.rank, -1, "Statement 0 should be unranked after clear");
-        assertEq(
-            forum.rankedCount(),
-            1,
-            "Only one statement should remain ranked"
-        );
+        // New step should succeed
+        forum.requireStep(stepAfter);
     }
 }

--- a/blockchain/contracts/Forum.t.sol
+++ b/blockchain/contracts/Forum.t.sol
@@ -178,7 +178,7 @@ contract ForumTest is Test {
     }
 
     function testAddStatement() external registeredMember {
-        forum.addStatement("Hello, world!");
+        forum.addStatement("Hello, world!", 0);
         assertEq(
             forum.statementCount(),
             1,
@@ -196,7 +196,7 @@ contract ForumTest is Test {
     }
 
     function testAddStatementSupport() external registeredMember {
-        forum.addStatement("Hello, world!");
+        forum.addStatement("Hello, world!", 0);
         _addStatementSupport(0, 1);
 
         Forum.Statement memory statement = _getStatementById(0);
@@ -208,7 +208,7 @@ contract ForumTest is Test {
     // ======================================================================
 
     function testSupportOfOneDoesNotCauseRanking() external registeredMember {
-        forum.addStatement("Test statement");
+        forum.addStatement("Test statement", 0);
         _addStatementSupport(0, 1);
 
         Forum.Statement memory statement = _getStatementById(0);
@@ -221,7 +221,7 @@ contract ForumTest is Test {
         external
         registeredMember
     {
-        forum.addStatement("Test statement");
+        forum.addStatement("Test statement", 0);
         _addStatementSupport(0, 2);
 
         Forum.Statement memory statement = _getStatementById(0);
@@ -235,8 +235,8 @@ contract ForumTest is Test {
         registeredMember
     {
         // Create and rank two statements
-        forum.addStatement("Statement A");
-        forum.addStatement("Statement B");
+        forum.addStatement("Statement A", 0);
+        forum.addStatement("Statement B", 0);
         _addStatementSupport(0, 3); // Rank 0
         _addStatementSupport(1, 2); // Rank 1
 
@@ -270,8 +270,8 @@ contract ForumTest is Test {
         registeredMember
     {
         // Create and rank two statements
-        forum.addStatement("Statement A");
-        forum.addStatement("Statement B");
+        forum.addStatement("Statement A", 0);
+        forum.addStatement("Statement B", 0);
         _addStatementSupport(0, 5); // Rank 0
         _addStatementSupport(1, 3); // Rank 1
 
@@ -293,9 +293,9 @@ contract ForumTest is Test {
 
     function testRemovingSupportLowersRank() external registeredMember {
         // Create and rank three statements
-        forum.addStatement("Statement A");
-        forum.addStatement("Statement B");
-        forum.addStatement("Statement C");
+        forum.addStatement("Statement A", 0);
+        forum.addStatement("Statement B", 0);
+        forum.addStatement("Statement C", 0);
         _addStatementSupport(0, 5); // Rank 0
         _addStatementSupport(1, 4); // Rank 1
         _addStatementSupport(2, 3); // Rank 2
@@ -325,7 +325,7 @@ contract ForumTest is Test {
         external
         registeredMember
     {
-        forum.addStatement("Test statement");
+        forum.addStatement("Test statement", 0);
         _addStatementSupport(0, 3); // Gets ranked
 
         assertEq(_getStatementById(0).rank, 0, "Statement should be ranked");
@@ -344,8 +344,8 @@ contract ForumTest is Test {
         external
         registeredMember
     {
-        forum.addStatement("Statement A");
-        forum.addStatement("Statement B");
+        forum.addStatement("Statement A", 0);
+        forum.addStatement("Statement B", 0);
         _addStatementSupport(0, 10); // Rank 0
         _addStatementSupport(1, 3); // Rank 1
 
@@ -377,7 +377,7 @@ contract ForumTest is Test {
         external
         registeredMember
     {
-        forum.addStatement("Test statement");
+        forum.addStatement("Test statement", 0);
         uint initialBalance = forum.getUserBalance();
 
         _addStatementSupport(0, 3); // Cost should be 6 (triangular number)
@@ -394,7 +394,7 @@ contract ForumTest is Test {
         external
         registeredMember
     {
-        forum.addStatement("Test statement");
+        forum.addStatement("Test statement", 0);
         _addStatementSupport(0, 5); // Cost: 15
         uint balanceAfterAdding = forum.getUserBalance();
 
@@ -412,7 +412,7 @@ contract ForumTest is Test {
         external
         registeredMember
     {
-        forum.addStatement("Test statement");
+        forum.addStatement("Test statement", 0);
 
         // Spend most of the balance
         uint currentBalance = forum.getUserBalance();
@@ -489,7 +489,7 @@ contract ForumTest is Test {
     }
 
     function testMarginalCostIsCorrect() external registeredMember {
-        forum.addStatement("Test statement");
+        forum.addStatement("Test statement", 0);
 
         // The marginal cost of the (n+1)th unit is n+1
         // When going from n to n+1, the cost change is:
@@ -524,9 +524,9 @@ contract ForumTest is Test {
         external
         registeredMember
     {
-        forum.addStatement("Statement A");
-        forum.addStatement("Statement B");
-        forum.addStatement("Statement C");
+        forum.addStatement("Statement A", 0);
+        forum.addStatement("Statement B", 0);
+        forum.addStatement("Statement C", 0);
 
         uint initialBalance = forum.getUserBalance();
 
@@ -569,7 +569,7 @@ contract ForumTest is Test {
     // ======================================================================
 
     function testStatementSupportDecaysOverTime() external registeredMember {
-        forum.addStatement("Test statement");
+        forum.addStatement("Test statement", 0);
         _addStatementSupport(0, 10);
 
         int supportBefore = _getStatementById(0).support;
@@ -589,7 +589,7 @@ contract ForumTest is Test {
     }
 
     function testAdjustingSupportAccountsForDecay() external registeredMember {
-        forum.addStatement("Test statement");
+        forum.addStatement("Test statement", 0);
         _addStatementSupport(0, 10);
 
         // Advance time to cause decay
@@ -610,8 +610,8 @@ contract ForumTest is Test {
 
     function testRankingUpdatedAfterSupportDecay() external registeredMember {
         // Create two statements with different support levels
-        forum.addStatement("Statement A");
-        forum.addStatement("Statement B");
+        forum.addStatement("Statement A", 0);
+        forum.addStatement("Statement B", 0);
         _addStatementSupport(0, 20); // High initial support
         _addStatementSupport(1, 10); // Lower initial support
 
@@ -650,7 +650,7 @@ contract ForumTest is Test {
         external
         registeredMember
     {
-        forum.addStatement("Test statement");
+        forum.addStatement("Test statement", 0);
         _addStatementSupport(0, 10);
 
         // Check user's support immediately
@@ -700,7 +700,7 @@ contract ForumTest is Test {
         external
         registeredMember
     {
-        forum.addStatement("Test statement");
+        forum.addStatement("Test statement", 0);
 
         uint initialBalance = forum.getUserBalance();
         _addStatementSupport(0, 10); // Cost: 55
@@ -735,7 +735,7 @@ contract ForumTest is Test {
         external
         registeredMember
     {
-        forum.addStatement("Test statement");
+        forum.addStatement("Test statement", 0);
         _addStatementSupport(0, 10);
 
         // Verify statement is in user's support list
@@ -766,10 +766,10 @@ contract ForumTest is Test {
         external
         registeredMember
     {
-        forum.addStatement("Statement A");
-        forum.addStatement("Statement B");
-        forum.addStatement("Statement C");
-        forum.addStatement("Statement D");
+        forum.addStatement("Statement A", 0);
+        forum.addStatement("Statement B", 0);
+        forum.addStatement("Statement C", 0);
+        forum.addStatement("Statement D", 0);
 
         // Add support to fill up the ranking (maxRankedStatements = 3)
         Forum.SupportAdjustment[]
@@ -836,10 +836,10 @@ contract ForumTest is Test {
 
     function testNewItemsAreAddedToFirstEmptySlot() external registeredMember {
         // Create multiple statements
-        forum.addStatement("Statement A");
-        forum.addStatement("Statement B");
-        forum.addStatement("Statement C");
-        forum.addStatement("Statement D");
+        forum.addStatement("Statement A", 0);
+        forum.addStatement("Statement B", 0);
+        forum.addStatement("Statement C", 0);
+        forum.addStatement("Statement D", 0);
 
         // Support statements A, B, and C
         _addStatementSupport(0, 10);
@@ -903,11 +903,11 @@ contract ForumTest is Test {
         registeredMember
     {
         // Create 5 statements: A, B, C, D, E
-        forum.addStatement("Statement A");
-        forum.addStatement("Statement B");
-        forum.addStatement("Statement C");
-        forum.addStatement("Statement D");
-        forum.addStatement("Statement E");
+        forum.addStatement("Statement A", 0);
+        forum.addStatement("Statement B", 0);
+        forum.addStatement("Statement C", 0);
+        forum.addStatement("Statement D", 0);
+        forum.addStatement("Statement E", 0);
 
         // Support all 5 statements - array will be [A, B, C, D, E]
         _addStatementSupport(0, 10);
@@ -949,7 +949,7 @@ contract ForumTest is Test {
 
         // Now add support to a new statement F
         // F fills the first empty slot; no further compaction occurs
-        forum.addStatement("Statement F");
+        forum.addStatement("Statement F", 0);
         _addStatementSupport(5, 5);
 
         // Verify array length stays at 4 (F just filled an empty slot)
@@ -993,7 +993,7 @@ contract ForumTest is Test {
         external
         registeredMember
     {
-        forum.addStatement("Fresh statement");
+        forum.addStatement("Fresh statement", 0);
         Forum.Statement memory s = _getStatementById(0);
         assertEq(s.rank, -1, "New statement should not be ranked");
         assertEq(
@@ -1004,7 +1004,7 @@ contract ForumTest is Test {
     }
 
     function testPeakRankTracksFirstRanking() external registeredMember {
-        forum.addStatement("Test statement");
+        forum.addStatement("Test statement", 0);
         _addStatementSupport(0, 3); // Gets ranked at position 0
 
         Forum.Statement memory s = _getStatementById(0);
@@ -1013,8 +1013,8 @@ contract ForumTest is Test {
     }
 
     function testPeakRankImprovesWhenRankImproves() external registeredMember {
-        forum.addStatement("Statement A");
-        forum.addStatement("Statement B");
+        forum.addStatement("Statement A", 0);
+        forum.addStatement("Statement B", 0);
         _addStatementSupport(0, 5); // Rank 0
         _addStatementSupport(1, 3); // Rank 1
 
@@ -1039,8 +1039,8 @@ contract ForumTest is Test {
         external
         registeredMember
     {
-        forum.addStatement("Statement A");
-        forum.addStatement("Statement B");
+        forum.addStatement("Statement A", 0);
+        forum.addStatement("Statement B", 0);
         _addStatementSupport(0, 5); // Rank 0
         _addStatementSupport(1, 3); // Rank 1
 
@@ -1059,10 +1059,10 @@ contract ForumTest is Test {
 
     function testPeakRankPreservedAfterEviction() external registeredMember {
         // maxRankedStatements = 3 from setUp, so fill 3 slots then evict the lowest
-        forum.addStatement("Statement A");
-        forum.addStatement("Statement B");
-        forum.addStatement("Statement C");
-        forum.addStatement("Statement D");
+        forum.addStatement("Statement A", 0);
+        forum.addStatement("Statement B", 0);
+        forum.addStatement("Statement C", 0);
+        forum.addStatement("Statement D", 0);
 
         // Rank A, B, C to fill all 3 slots
         _addStatementSupport(0, 6); // Rank 0
@@ -1084,9 +1084,9 @@ contract ForumTest is Test {
     function testPeakRankTracksDisplacedStatements() external registeredMember {
         // When statement X rises in rank, statements it displaces get
         // their rank set via _setStatementRank, which should also track peakRank.
-        forum.addStatement("Statement A");
-        forum.addStatement("Statement B");
-        forum.addStatement("Statement C");
+        forum.addStatement("Statement A", 0);
+        forum.addStatement("Statement B", 0);
+        forum.addStatement("Statement C", 0);
         _addStatementSupport(0, 6); // Rank 0
         _addStatementSupport(1, 4); // Rank 1
         _addStatementSupport(2, 2); // Rank 2
@@ -1123,7 +1123,7 @@ contract ForumTest is Test {
         external
         registeredMember
     {
-        forum.addStatement("Statement A");
+        forum.addStatement("Statement A", 0);
         vm.expectEmit(true, false, false, true);
         emit Forum.StatementRankChanged(0, -1, 0);
         _addStatementSupport(0, 3); // Statement A should go from unranked (-1) to rank 0
@@ -1133,8 +1133,8 @@ contract ForumTest is Test {
         external
         registeredMember
     {
-        forum.addStatement("Statement A");
-        forum.addStatement("Statement B");
+        forum.addStatement("Statement A", 0);
+        forum.addStatement("Statement B", 0);
         _addStatementSupport(0, 5); // A rank 0
         _addStatementSupport(1, 3); // B rank 1
 
@@ -1151,10 +1151,10 @@ contract ForumTest is Test {
         registeredMember
     {
         // maxRankedStatements = 3
-        forum.addStatement("Statement A");
-        forum.addStatement("Statement B");
-        forum.addStatement("Statement C");
-        forum.addStatement("Statement D"); // NOT ranked (4th exceeds max)
+        forum.addStatement("Statement A", 0);
+        forum.addStatement("Statement B", 0);
+        forum.addStatement("Statement C", 0);
+        forum.addStatement("Statement D", 0); // NOT ranked (4th exceeds max)
 
         _addStatementSupport(0, 6); // A rank 0
         _addStatementSupport(1, 4); // B rank 1
@@ -1174,8 +1174,8 @@ contract ForumTest is Test {
         external
         registeredMember
     {
-        forum.addStatement("Statement A");
-        forum.addStatement("Statement B");
+        forum.addStatement("Statement A", 0);
+        forum.addStatement("Statement B", 0);
         _addStatementSupport(0, 5);
         _addStatementSupport(1, 3);
 
@@ -1189,8 +1189,8 @@ contract ForumTest is Test {
         external
         registeredMember
     {
-        forum.addStatement("Statement A");
-        forum.addStatement("Statement B");
+        forum.addStatement("Statement A", 0);
+        forum.addStatement("Statement B", 0);
         _addStatementSupport(0, 10); // Rank 0
         _addStatementSupport(1, 3); // Rank 1
 
@@ -1216,12 +1216,70 @@ contract ForumTest is Test {
         }
     }
 
+    function testSupportBelowThresholdUnranksImmediatelyFromMiddle()
+        external
+        registeredMember
+    {
+        // Three ranked statements; remove support from the top-ranked one
+        // so it drops below threshold. It should be unranked immediately,
+        // not deferred to maintenance.
+        forum.addStatement("Statement A", 0);
+        forum.addStatement("Statement B", 0);
+        forum.addStatement("Statement C", 0);
+        _addStatementSupport(0, 6); // Rank 0
+        _addStatementSupport(1, 4); // Rank 1
+        _addStatementSupport(2, 3); // Rank 2
+
+        assertEq(forum.rankedCount(), 3, "All three should be ranked");
+
+        // Drop A's support to 1 (below minStatementSupportToRank = 2)
+        _addStatementSupport(0, -5);
+
+        Forum.Statement memory sA = _getStatementById(0);
+        assertEq(sA.rank, -1, "Statement A should be immediately unranked");
+        assertEq(
+            forum.rankedCount(),
+            2,
+            "Ranked count should be 2 after eviction"
+        );
+
+        // B and C should remain ranked and compact correctly
+        Forum.Statement memory sB = _getStatementById(1);
+        Forum.Statement memory sC = _getStatementById(2);
+        assertEq(sB.rank, 0, "Statement B should be rank 0");
+        assertEq(sC.rank, 1, "Statement C should be rank 1");
+    }
+
+    function testSupportBelowThresholdUnranksFromSecondPosition()
+        external
+        registeredMember
+    {
+        // Remove support from the middle-ranked statement
+        forum.addStatement("Statement A", 0);
+        forum.addStatement("Statement B", 0);
+        forum.addStatement("Statement C", 0);
+        _addStatementSupport(0, 6); // Rank 0
+        _addStatementSupport(1, 4); // Rank 1
+        _addStatementSupport(2, 3); // Rank 2
+
+        // Drop B's support below threshold
+        _addStatementSupport(1, -3); // B now has 1 support
+
+        Forum.Statement memory sB = _getStatementById(1);
+        assertEq(sB.rank, -1, "Statement B should be immediately unranked");
+        assertEq(forum.rankedCount(), 2, "Ranked count should be 2");
+
+        // A stays rank 0, C moves up to rank 1
+        assertEq(_getStatementById(0).rank, 0, "Statement A should be rank 0");
+        assertEq(_getStatementById(2).rank, 1, "Statement C should be rank 1");
+    }
+
     // ======================================================================
     // Section: StatementEngaged event
     // ======================================================================
 
     function testEngagedEmittedOnFirstInteraction() external registeredMember {
-        forum.addStatement("Statement A");
+        forum.addStatement("Statement A", 0);
 
         // First interaction should always emit (lastEngagementEventTimestamp = 0)
         vm.recordLogs();
@@ -1244,7 +1302,7 @@ contract ForumTest is Test {
     }
 
     function testEngagedNotEmittedWithinWindow() external registeredMember {
-        forum.addStatement("Statement A");
+        forum.addStatement("Statement A", 0);
         _addStatementSupport(0, 1); // First interaction emits
 
         // Interact again within the engagement window (< 60s)
@@ -1270,7 +1328,7 @@ contract ForumTest is Test {
     }
 
     function testEngagedEmittedAfterWindowExpires() external registeredMember {
-        forum.addStatement("Statement A");
+        forum.addStatement("Statement A", 0);
         _addStatementSupport(0, 1); // First interaction emits
 
         // Advance past the engagement window (>= 60s)
@@ -1282,8 +1340,8 @@ contract ForumTest is Test {
     }
 
     function testEngagedWindowIsPerStatement() external registeredMember {
-        forum.addStatement("Statement A");
-        forum.addStatement("Statement B");
+        forum.addStatement("Statement A", 0);
+        forum.addStatement("Statement B", 0);
 
         _addStatementSupport(0, 1); // Emits for A
 
@@ -1311,7 +1369,7 @@ contract ForumTest is Test {
     }
 
     function testEngagedTimestampResetsOnEmission() external registeredMember {
-        forum.addStatement("Statement A");
+        forum.addStatement("Statement A", 0);
         _addStatementSupport(0, 1); // t=0, emits
 
         // Advance past window
@@ -1345,5 +1403,63 @@ contract ForumTest is Test {
         vm.expectEmit(true, false, false, false);
         emit Forum.StatementEngaged(0);
         _addStatementSupport(0, 1);
+    }
+
+    function testClearSupportResetsSupportAndRefundsCredits()
+        external
+        registeredMember
+    {
+        forum.addStatement("Statement A", 0);
+        forum.addStatement("Statement B", 0);
+
+        _addStatementSupport(0, 5); // Cost: 15
+        _addStatementSupport(1, 3); // Cost: 6
+
+        uint balanceAfterSupport = forum.getUserBalance();
+
+        // Clear support on both statements
+        uint[] memory statementIds = new uint[](2);
+        statementIds[0] = 0;
+        statementIds[1] = 1;
+        forum.clearSupport(statementIds);
+
+        // Support should be zero
+        Forum.Statement memory s0 = _getStatementById(0);
+        Forum.Statement memory s1 = _getStatementById(1);
+        assertEq(s0.support, 0, "Statement 0 support should be 0 after clear");
+        assertEq(s1.support, 0, "Statement 1 support should be 0 after clear");
+
+        // Credits should be fully refunded (15 + 6 = 21)
+        uint finalBalance = forum.getUserBalance();
+        assertEq(
+            finalBalance,
+            balanceAfterSupport + 21,
+            "Credits should be refunded by 21 after clearing support"
+        );
+    }
+
+    function testClearSupportRemovesFromRanking() external registeredMember {
+        forum.addStatement("Statement A", 0);
+        forum.addStatement("Statement B", 0);
+
+        _addStatementSupport(0, 5); // Ranked
+        _addStatementSupport(1, 3); // Ranked
+
+        // Verify both are ranked
+        assertEq(forum.rankedCount(), 2, "Both statements should be ranked");
+
+        // Clear support on statement 0
+        uint[] memory statementIds = new uint[](1);
+        statementIds[0] = 0;
+        forum.clearSupport(statementIds);
+
+        // Statement 0 should be immediately unranked
+        Forum.Statement memory s0 = _getStatementById(0);
+        assertEq(s0.rank, -1, "Statement 0 should be unranked after clear");
+        assertEq(
+            forum.rankedCount(),
+            1,
+            "Only one statement should remain ranked"
+        );
     }
 }

--- a/blockchain/ignition/modules/ForumMockedRegistry.ts
+++ b/blockchain/ignition/modules/ForumMockedRegistry.ts
@@ -5,6 +5,8 @@ type MockStatement = {
   addrIndex: number;
   forum: string;
   content: string;
+  /** Initial support applied by the author at creation time (default 0). */
+  initialSupport?: number;
 };
 
 type MockSupport = {
@@ -20,45 +22,63 @@ const MOCK_STATEMENTS: MockStatement[] = [
     addrIndex: 0,
     forum: "USA",
     content: "Access to high-quality medical care is a human right.",
+    initialSupport: 10,
   },
   {
     addrIndex: 0,
     forum: "USA",
     content: "We need to consider and prevent the potential downsides of AI.",
+    initialSupport: 10,
   },
   {
     addrIndex: 0,
     forum: "USA",
     content: "Loneliness is an epidemic. Touch grass, find a friend.",
+    initialSupport: 10,
   },
-  { addrIndex: 0, forum: "USA", content: "We're better together." },
-  { addrIndex: 0, forum: "USA", content: "I want something to believe in." },
+  {
+    addrIndex: 0,
+    forum: "USA",
+    content: "We're better together.",
+    initialSupport: 10,
+  },
+  {
+    addrIndex: 0,
+    forum: "USA",
+    content: "I want something to believe in.",
+    initialSupport: 10,
+  },
   {
     addrIndex: 0,
     forum: "USA",
     content: "Nothing heals like a good chocolate chip cookie!",
+    initialSupport: 10,
   },
   {
     addrIndex: 0,
     forum: "USA",
     content: "We're in the longest government shutdown in our history.",
+    initialSupport: 10,
   },
   {
     addrIndex: 0,
     forum: "USA",
     content: "All work and now play makes Hannah and sad girl",
+    initialSupport: 10,
   },
   {
     addrIndex: 0,
     forum: "USA",
     content:
       "We should continue providing SNAP benefits despite the government shutdown",
+    initialSupport: 10,
   },
   {
     addrIndex: 0,
     forum: "USA",
     content:
       "There should be a minimum of 4 weeks PTO for primary care givers.",
+    initialSupport: 10,
   },
   { addrIndex: 0, forum: "global", content: "Gazan's deserve to not starve." },
   {
@@ -71,16 +91,19 @@ const MOCK_STATEMENTS: MockStatement[] = [
     addrIndex: 1,
     forum: "CAN",
     content: "Universal healthcare is something to be proud of.",
+    initialSupport: 10,
   },
   {
     addrIndex: 1,
     forum: "CAN",
     content: "We need more affordable housing in our cities.",
+    initialSupport: 10,
   },
   {
     addrIndex: 1,
     forum: "CAN",
     content: "Reconciliation with Indigenous peoples must be a priority.",
+    initialSupport: 10,
   },
 ];
 
@@ -96,31 +119,19 @@ const MOCK_STATEMENTS: MockStatement[] = [
  *   - account 1 (nationality "CAN") → member of CAN & global
  *   - account 2 (nationality "")    → member of global only
  */
+/**
+ * Cross-user support votes. Author self-support is now handled by
+ * initialSupport in MOCK_STATEMENTS above, so only votes from users
+ * other than the statement author remain here.
+ */
 const MOCK_SUPPORT: MockSupport[] = [
-  // ── USA forum: only account 0 is a member, so one user gives +2 ──
-  { addrIndex: 0, forum: "USA", statementIndex: 0, value: 10 },
-  { addrIndex: 0, forum: "USA", statementIndex: 1, value: 10 },
-  { addrIndex: 0, forum: "USA", statementIndex: 2, value: 10 },
-  { addrIndex: 0, forum: "USA", statementIndex: 3, value: 10 },
-  { addrIndex: 0, forum: "USA", statementIndex: 4, value: 10 },
-  { addrIndex: 0, forum: "USA", statementIndex: 5, value: 10 },
-  { addrIndex: 0, forum: "USA", statementIndex: 6, value: 10 },
-  { addrIndex: 0, forum: "USA", statementIndex: 7, value: 10 },
-  { addrIndex: 0, forum: "USA", statementIndex: 8, value: 10 },
-  { addrIndex: 0, forum: "USA", statementIndex: 9, value: 10 },
-
-  // ── global forum: accounts 0, 1, 2 are all members ──
+  // ── global forum: support from users other than the author ──
   { addrIndex: 1, forum: "global", statementIndex: 0, value: 10 },
   { addrIndex: 2, forum: "global", statementIndex: 0, value: 10 },
   { addrIndex: 0, forum: "global", statementIndex: 1, value: 10 },
   { addrIndex: 2, forum: "global", statementIndex: 1, value: 10 },
   { addrIndex: 0, forum: "global", statementIndex: 2, value: 10 },
   { addrIndex: 1, forum: "global", statementIndex: 2, value: 10 },
-
-  // ── CAN forum: only account 1 is a member, so one user gives +2 ──
-  { addrIndex: 1, forum: "CAN", statementIndex: 0, value: 10 },
-  { addrIndex: 1, forum: "CAN", statementIndex: 1, value: 10 },
-  { addrIndex: 1, forum: "CAN", statementIndex: 2, value: 10 },
 ];
 
 /**
@@ -175,7 +186,7 @@ export function createForumMockedModule(
     const statementFutures: Record<string, ReturnType<typeof m.call>[]> = {};
     MOCK_STATEMENTS.forEach((stmt, idx) => {
       const fromAddress = m.getAccount(stmt.addrIndex);
-      const future = m.call(forums[stmt.forum], "addStatement", [stmt.content], {
+      const future = m.call(forums[stmt.forum], "addStatement", [stmt.content, BigInt(stmt.initialSupport ?? 0)], {
         id: `addMockStatement${idx}`,
         from: fromAddress,
       });

--- a/blockchain/package-lock.json
+++ b/blockchain/package-lock.json
@@ -8,6 +8,9 @@
       "name": "ourvoice-backend",
       "version": "0.0.1",
       "license": "Apache-2.0",
+      "dependencies": {
+        "@openzeppelin/contracts": "^5.6.1"
+      },
       "devDependencies": {
         "@nomicfoundation/hardhat-ignition": "^3.0.0",
         "@nomicfoundation/hardhat-keystore": "^3.0.1",
@@ -28,7 +31,6 @@
       "integrity": "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@actions/exec": "^1.1.1",
         "@actions/http-client": "^2.0.1"
@@ -40,7 +42,6 @@
       "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@actions/io": "^1.0.1"
       }
@@ -51,7 +52,6 @@
       "integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tunnel": "^0.0.6",
         "undici": "^5.25.4"
@@ -62,8 +62,7 @@
       "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
       "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@adraffy/ens-normalize": {
       "version": "1.10.1",
@@ -536,7 +535,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethersproject/address": "^5.8.0",
         "@ethersproject/bignumber": "^5.8.0",
@@ -565,7 +563,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethersproject/bignumber": "^5.8.0",
         "@ethersproject/bytes": "^5.8.0",
@@ -592,7 +589,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethersproject/abstract-provider": "^5.8.0",
         "@ethersproject/bignumber": "^5.8.0",
@@ -617,7 +613,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethersproject/bignumber": "^5.8.0",
         "@ethersproject/bytes": "^5.8.0",
@@ -642,7 +637,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.8.0"
       }
@@ -705,7 +699,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethersproject/bignumber": "^5.8.0"
       }
@@ -726,7 +719,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethersproject/abstract-signer": "^5.8.0",
         "@ethersproject/address": "^5.8.0",
@@ -793,7 +785,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethersproject/logger": "^5.8.0"
       }
@@ -814,7 +805,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethersproject/logger": "^5.8.0"
       }
@@ -856,7 +846,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.8.0",
         "@ethersproject/logger": "^5.8.0",
@@ -882,7 +871,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.8.0",
         "@ethersproject/constants": "^5.8.0",
@@ -905,7 +893,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethersproject/address": "^5.8.0",
         "@ethersproject/bignumber": "^5.8.0",
@@ -934,7 +921,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethersproject/base64": "^5.8.0",
         "@ethersproject/bytes": "^5.8.0",
@@ -949,7 +935,6 @@
       "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -960,7 +945,6 @@
       "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sinclair/typebox": "^0.27.8"
       },
@@ -1116,6 +1100,7 @@
       "integrity": "sha512-vSK2rDteXObVBMPa00T8xZJ/qU5UsfPuBL9kDao1ZW9flz+kgsmrWW7YbcgVvx6UaAAG0MfZOS2wtCXaGZ3i3g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@nomicfoundation/hardhat-errors": "^3.0.0",
         "@nomicfoundation/hardhat-utils": "^3.0.0",
@@ -1155,6 +1140,7 @@
       "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-keystore/-/hardhat-keystore-3.0.1.tgz",
       "integrity": "sha512-IHjTWf88Kp6ZsnwngVYNJphWwwhnkSjg+wBd9im5yo8IbvCjd0Otyv2ucw0Dol+mxM3t/6XJhEnhbA3JGe/EdQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@noble/ciphers": "1.2.1",
         "@noble/hashes": "1.7.1",
@@ -1174,6 +1160,7 @@
       "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-network-helpers/-/hardhat-network-helpers-3.0.1.tgz",
       "integrity": "sha512-bNDZJawEEZhUQkUwvwlM5lLwcEBxQ5wNYDZsNHeiycPcYsDRhSFDuVPuKppJ78NGGnDUiwVsEogr/kRcQHk9rg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@nomicfoundation/hardhat-errors": "^3.0.0",
         "@nomicfoundation/hardhat-utils": "^3.0.3"
@@ -1188,7 +1175,6 @@
       "integrity": "sha512-sVUXtujMpyamS0Ap263Nxkb0Vjq7WGvE4GLIJYPV7JEm1VcILUzMdEU36YOx5aVoA+fDCVRFfn342mR4C81syA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@actions/core": "^1.10.1",
         "chalk": "^5.3.0",
@@ -1334,6 +1320,7 @@
       "integrity": "sha512-4vrRTaUSSMbH7FpM40EeOH/7GvHUcLjmY2uFdAThf/bytTrQyryOuOSggWDAOj1Ahov+KEfgDapY6s1MexjCCA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ethersproject/address": "5.6.1",
         "@nomicfoundation/hardhat-errors": "^3.0.0",
@@ -1482,6 +1469,12 @@
         "node": ">= 12"
       }
     },
+    "node_modules/@openzeppelin/contracts": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-5.6.1.tgz",
+      "integrity": "sha512-Ly6SlsVJ3mj+b18W3R8gNufB7dTICT105fJhodGAGgyC2oqnBAhqSiNDJ8V8DLY05cCz81GLI0CU5vNYA1EC/w==",
+      "license": "MIT"
+    },
     "node_modules/@scure/base": {
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
@@ -1562,8 +1555,7 @@
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
       "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@solidity-parser/parser": {
       "version": "0.20.2",
@@ -1663,7 +1655,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -1683,8 +1674,7 @@
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/cbor2": {
       "version": "1.12.0",
@@ -1730,7 +1720,6 @@
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -1743,8 +1732,7 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.1",
@@ -1770,7 +1758,6 @@
       "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -1781,7 +1768,6 @@
       "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",
@@ -1797,8 +1783,7 @@
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
       "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/enquirer": {
       "version": "2.4.1",
@@ -2020,6 +2005,7 @@
       "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-3.0.17.tgz",
       "integrity": "sha512-8Y2AEpDaAoGMdyePDBHaphwDgWfKvW5hEXtb5Dc7YakGX8xeL/4RWWejp4KiL5jvcb0oZ6s522fLyNUQxtPq0g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@nomicfoundation/edr": "0.12.0-next.16",
         "@nomicfoundation/hardhat-errors": "^3.0.6",
@@ -2073,7 +2059,6 @@
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2084,7 +2069,6 @@
       "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
@@ -2096,7 +2080,6 @@
       "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
@@ -2143,7 +2126,6 @@
       "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chalk": "^4.0.0",
         "diff-sequences": "^29.6.3",
@@ -2160,7 +2142,6 @@
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -2177,7 +2158,6 @@
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -2195,7 +2175,6 @@
       "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -2323,16 +2302,14 @@
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
       "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/minimalistic-crypto-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
       "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/minimist": {
       "version": "1.2.8",
@@ -2508,6 +2485,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz",
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -2541,7 +2519,6 @@
       "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
@@ -2570,8 +2547,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/readable-stream": {
       "version": "3.6.2",
@@ -2707,7 +2683,6 @@
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -2758,7 +2733,6 @@
       "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
       }
@@ -2769,6 +2743,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2783,7 +2758,6 @@
       "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
       },
@@ -2817,6 +2791,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@noble/curves": "1.9.2",
         "@noble/hashes": "1.8.0",
@@ -2932,6 +2907,7 @@
       "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -2954,6 +2930,7 @@
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/blockchain/package-lock.json
+++ b/blockchain/package-lock.json
@@ -31,6 +31,7 @@
       "integrity": "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@actions/exec": "^1.1.1",
         "@actions/http-client": "^2.0.1"
@@ -42,6 +43,7 @@
       "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@actions/io": "^1.0.1"
       }
@@ -52,6 +54,7 @@
       "integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tunnel": "^0.0.6",
         "undici": "^5.25.4"
@@ -62,7 +65,8 @@
       "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
       "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@adraffy/ens-normalize": {
       "version": "1.10.1",
@@ -535,6 +539,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ethersproject/address": "^5.8.0",
         "@ethersproject/bignumber": "^5.8.0",
@@ -563,6 +568,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ethersproject/bignumber": "^5.8.0",
         "@ethersproject/bytes": "^5.8.0",
@@ -589,6 +595,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ethersproject/abstract-provider": "^5.8.0",
         "@ethersproject/bignumber": "^5.8.0",
@@ -613,6 +620,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ethersproject/bignumber": "^5.8.0",
         "@ethersproject/bytes": "^5.8.0",
@@ -637,6 +645,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.8.0"
       }
@@ -699,6 +708,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ethersproject/bignumber": "^5.8.0"
       }
@@ -719,6 +729,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ethersproject/abstract-signer": "^5.8.0",
         "@ethersproject/address": "^5.8.0",
@@ -785,6 +796,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ethersproject/logger": "^5.8.0"
       }
@@ -805,6 +817,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ethersproject/logger": "^5.8.0"
       }
@@ -846,6 +859,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.8.0",
         "@ethersproject/logger": "^5.8.0",
@@ -871,6 +885,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.8.0",
         "@ethersproject/constants": "^5.8.0",
@@ -893,6 +908,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ethersproject/address": "^5.8.0",
         "@ethersproject/bignumber": "^5.8.0",
@@ -921,6 +937,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ethersproject/base64": "^5.8.0",
         "@ethersproject/bytes": "^5.8.0",
@@ -935,6 +952,7 @@
       "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -945,6 +963,7 @@
       "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@sinclair/typebox": "^0.27.8"
       },
@@ -1100,7 +1119,6 @@
       "integrity": "sha512-vSK2rDteXObVBMPa00T8xZJ/qU5UsfPuBL9kDao1ZW9flz+kgsmrWW7YbcgVvx6UaAAG0MfZOS2wtCXaGZ3i3g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nomicfoundation/hardhat-errors": "^3.0.0",
         "@nomicfoundation/hardhat-utils": "^3.0.0",
@@ -1140,7 +1158,6 @@
       "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-keystore/-/hardhat-keystore-3.0.1.tgz",
       "integrity": "sha512-IHjTWf88Kp6ZsnwngVYNJphWwwhnkSjg+wBd9im5yo8IbvCjd0Otyv2ucw0Dol+mxM3t/6XJhEnhbA3JGe/EdQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@noble/ciphers": "1.2.1",
         "@noble/hashes": "1.7.1",
@@ -1160,7 +1177,6 @@
       "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-network-helpers/-/hardhat-network-helpers-3.0.1.tgz",
       "integrity": "sha512-bNDZJawEEZhUQkUwvwlM5lLwcEBxQ5wNYDZsNHeiycPcYsDRhSFDuVPuKppJ78NGGnDUiwVsEogr/kRcQHk9rg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@nomicfoundation/hardhat-errors": "^3.0.0",
         "@nomicfoundation/hardhat-utils": "^3.0.3"
@@ -1175,6 +1191,7 @@
       "integrity": "sha512-sVUXtujMpyamS0Ap263Nxkb0Vjq7WGvE4GLIJYPV7JEm1VcILUzMdEU36YOx5aVoA+fDCVRFfn342mR4C81syA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@actions/core": "^1.10.1",
         "chalk": "^5.3.0",
@@ -1320,7 +1337,6 @@
       "integrity": "sha512-4vrRTaUSSMbH7FpM40EeOH/7GvHUcLjmY2uFdAThf/bytTrQyryOuOSggWDAOj1Ahov+KEfgDapY6s1MexjCCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethersproject/address": "5.6.1",
         "@nomicfoundation/hardhat-errors": "^3.0.0",
@@ -1555,7 +1571,8 @@
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
       "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@solidity-parser/parser": {
       "version": "0.20.2",
@@ -1655,6 +1672,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -1674,7 +1692,8 @@
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/cbor2": {
       "version": "1.12.0",
@@ -1720,6 +1739,7 @@
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -1732,7 +1752,8 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/debug": {
       "version": "4.4.1",
@@ -1758,6 +1779,7 @@
       "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -1768,6 +1790,7 @@
       "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",
@@ -1783,7 +1806,8 @@
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
       "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/enquirer": {
       "version": "2.4.1",
@@ -2005,7 +2029,6 @@
       "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-3.0.17.tgz",
       "integrity": "sha512-8Y2AEpDaAoGMdyePDBHaphwDgWfKvW5hEXtb5Dc7YakGX8xeL/4RWWejp4KiL5jvcb0oZ6s522fLyNUQxtPq0g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@nomicfoundation/edr": "0.12.0-next.16",
         "@nomicfoundation/hardhat-errors": "^3.0.6",
@@ -2059,6 +2082,7 @@
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2069,6 +2093,7 @@
       "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
@@ -2080,6 +2105,7 @@
       "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
@@ -2126,6 +2152,7 @@
       "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chalk": "^4.0.0",
         "diff-sequences": "^29.6.3",
@@ -2142,6 +2169,7 @@
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -2158,6 +2186,7 @@
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -2175,6 +2204,7 @@
       "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -2302,14 +2332,16 @@
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
       "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/minimalistic-crypto-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
       "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/minimist": {
       "version": "1.2.8",
@@ -2485,7 +2517,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz",
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -2519,6 +2550,7 @@
       "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
@@ -2547,7 +2579,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/readable-stream": {
       "version": "3.6.2",
@@ -2683,6 +2716,7 @@
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -2733,6 +2767,7 @@
       "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
       }
@@ -2743,7 +2778,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2758,6 +2792,7 @@
       "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
       },
@@ -2791,7 +2826,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@noble/curves": "1.9.2",
         "@noble/hashes": "1.8.0",
@@ -2907,7 +2941,6 @@
       "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -2930,7 +2963,6 @@
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/blockchain/package.json
+++ b/blockchain/package.json
@@ -31,5 +31,8 @@
     "prettier-plugin-solidity": "^2.2.1",
     "typescript": "~5.8.0",
     "viem": "^2.33.3"
+  },
+  "dependencies": {
+    "@openzeppelin/contracts": "^5.6.1"
   }
 }

--- a/frontend/src/components/AppBar.tsx
+++ b/frontend/src/components/AppBar.tsx
@@ -206,7 +206,7 @@ export default function MenuAppBar() {
 
   const {
     isUserVerified,
-    commitSupport,
+    commitChanges,
     resetCommitStatus,
     state: userVoteState,
   } = useUserVotes();
@@ -279,7 +279,7 @@ export default function MenuAppBar() {
                       navigate={(path: string) => void navigate(path)}
                       disconnect={doDisconnect}
                       avatar={avatar}
-                      commitSupport={commitSupport ?? (() => {})}
+                      commitChanges={commitChanges ?? (() => {})}
                       hasStagedChanges={
                         userVoteState?.hasStagedChanges ?? false
                       }

--- a/frontend/src/components/CommitSupportModal.tsx
+++ b/frontend/src/components/CommitSupportModal.tsx
@@ -52,7 +52,8 @@ const CommitSupportModal: FC<CommitSupportModalProps> = ({
     if (
       commitStatus === "cancelled" ||
       commitStatus === "error" ||
-      commitStatus === "confirmed"
+      commitStatus === "confirmed" ||
+      commitStatus === "stale-step"
     ) {
       onReset();
     }
@@ -99,6 +100,20 @@ const CommitSupportModal: FC<CommitSupportModalProps> = ({
               sx={{ fontSize: "3rem", color: "warning.main" }}
             />
             <Typography variant="body1">Something went wrong</Typography>
+          </Stack>
+        )}
+
+        {commitStatus === "stale-step" && (
+          <Stack spacing={2} alignItems="center">
+            <ErrorOutlineIcon
+              sx={{ fontSize: "3rem", color: "warning.main" }}
+            />
+            <Typography variant="body1">
+              Support values have shifted since you last reviewed.
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              Please review your changes and try again.
+            </Typography>
           </Stack>
         )}
       </Box>

--- a/frontend/src/components/Home.tsx
+++ b/frontend/src/components/Home.tsx
@@ -1,6 +1,7 @@
 import { FC, useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { useReadContract, useReadContracts } from "wagmi";
 import { useForum, FORUM_ABI } from "../state/Forum";
+import { useUserVotes, type StagedStatement } from "../state/UserVotes";
 import { Statement } from "../types";
 import StatementList from "./StatementList";
 import SortTabs, { SortMode } from "./SortTabs";
@@ -22,6 +23,10 @@ const Home: FC = () => {
   const isMobile = useIsMobile();
   const { has: isBookmarked, toggle: toggleBookmark } =
     useLocalStorageSet("bookmarks");
+  const userVotes = useUserVotes();
+
+  const stagedStatements = userVotes.state?.staged?.stagedStatements ?? [];
+  const unstageStatement = userVotes.unstageStatement;
 
   // ── Search state from context ───────────────────────────────────────────
   const { query: searchQuery } = useSearchQuery();
@@ -51,6 +56,8 @@ const Home: FC = () => {
           forumContractAddress={forumContractAddress}
           isBookmarked={isBookmarked}
           onToggleBookmark={toggleBookmark}
+          stagedStatements={stagedStatements}
+          onUnstagStatement={unstageStatement}
         />
       ) : (
         <RankedBrowse
@@ -58,6 +65,8 @@ const Home: FC = () => {
           isMobile={isMobile}
           isBookmarked={isBookmarked}
           onToggleBookmark={toggleBookmark}
+          stagedStatements={stagedStatements}
+          onUnstagStatement={unstageStatement}
         />
       )}
     </>
@@ -74,6 +83,8 @@ interface SearchResultsProps {
   forumContractAddress: `0x${string}`;
   isBookmarked: (id: number) => boolean;
   onToggleBookmark: (id: number) => void;
+  stagedStatements?: StagedStatement[];
+  onUnstagStatement?: (tempId: string) => void;
 }
 
 const SearchResults: FC<SearchResultsProps> = ({
@@ -82,6 +93,8 @@ const SearchResults: FC<SearchResultsProps> = ({
   forumContractAddress,
   isBookmarked,
   onToggleBookmark,
+  stagedStatements,
+  onUnstagStatement,
 }) => {
   const { hits, isLoading: isSearchLoading } = useSearch(searchQuery);
 
@@ -157,6 +170,8 @@ const SearchResults: FC<SearchResultsProps> = ({
       loadingLabel="Searching…"
       isBookmarked={isBookmarked}
       onToggleBookmark={onToggleBookmark}
+      stagedStatements={stagedStatements}
+      onUnstagStatement={onUnstagStatement}
     />
   );
 };
@@ -170,6 +185,8 @@ interface RankedBrowseProps {
   isMobile: boolean;
   isBookmarked: (id: number) => boolean;
   onToggleBookmark: (id: number) => void;
+  stagedStatements?: StagedStatement[];
+  onUnstagStatement?: (tempId: string) => void;
 }
 
 const RankedBrowse: FC<RankedBrowseProps> = ({
@@ -177,6 +194,8 @@ const RankedBrowse: FC<RankedBrowseProps> = ({
   isMobile,
   isBookmarked,
   onToggleBookmark,
+  stagedStatements,
+  onUnstagStatement,
 }) => {
   const PAGE_SIZE = isMobile ? 10 : 20;
 
@@ -267,6 +286,8 @@ const RankedBrowse: FC<RankedBrowseProps> = ({
       pageIndex={pageIndex}
       isBookmarked={isBookmarked}
       onToggleBookmark={onToggleBookmark}
+      stagedStatements={stagedStatements}
+      onUnstagStatement={onUnstagStatement}
     />
   );
 };

--- a/frontend/src/components/Home.tsx
+++ b/frontend/src/components/Home.tsx
@@ -153,7 +153,7 @@ const SearchResults: FC<SearchResultsProps> = ({
       statements={statements}
       hasMore={false}
       isLoading={isLoading}
-      onLoadMore={() => { }}
+      onLoadMore={() => {}}
       loadingLabel="Searching…"
       isBookmarked={isBookmarked}
       onToggleBookmark={onToggleBookmark}

--- a/frontend/src/components/Home.tsx
+++ b/frontend/src/components/Home.tsx
@@ -1,7 +1,6 @@
 import { FC, useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { useReadContract, useReadContracts } from "wagmi";
 import { useForum, FORUM_ABI } from "../state/Forum";
-import { useUserVotes, type StagedStatement } from "../state/UserVotes";
 import { Statement } from "../types";
 import StatementList from "./StatementList";
 import SortTabs, { SortMode } from "./SortTabs";
@@ -23,10 +22,6 @@ const Home: FC = () => {
   const isMobile = useIsMobile();
   const { has: isBookmarked, toggle: toggleBookmark } =
     useLocalStorageSet("bookmarks");
-  const userVotes = useUserVotes();
-
-  const stagedStatements = userVotes.state?.staged?.stagedStatements ?? [];
-  const unstageStatement = userVotes.unstageStatement;
 
   // ── Search state from context ───────────────────────────────────────────
   const { query: searchQuery } = useSearchQuery();
@@ -56,8 +51,6 @@ const Home: FC = () => {
           forumContractAddress={forumContractAddress}
           isBookmarked={isBookmarked}
           onToggleBookmark={toggleBookmark}
-          stagedStatements={stagedStatements}
-          onUnstagStatement={unstageStatement}
         />
       ) : (
         <RankedBrowse
@@ -65,8 +58,6 @@ const Home: FC = () => {
           isMobile={isMobile}
           isBookmarked={isBookmarked}
           onToggleBookmark={toggleBookmark}
-          stagedStatements={stagedStatements}
-          onUnstagStatement={unstageStatement}
         />
       )}
     </>
@@ -83,8 +74,6 @@ interface SearchResultsProps {
   forumContractAddress: `0x${string}`;
   isBookmarked: (id: number) => boolean;
   onToggleBookmark: (id: number) => void;
-  stagedStatements?: StagedStatement[];
-  onUnstagStatement?: (tempId: string) => void;
 }
 
 const SearchResults: FC<SearchResultsProps> = ({
@@ -93,8 +82,6 @@ const SearchResults: FC<SearchResultsProps> = ({
   forumContractAddress,
   isBookmarked,
   onToggleBookmark,
-  stagedStatements,
-  onUnstagStatement,
 }) => {
   const { hits, isLoading: isSearchLoading } = useSearch(searchQuery);
 
@@ -166,12 +153,10 @@ const SearchResults: FC<SearchResultsProps> = ({
       statements={statements}
       hasMore={false}
       isLoading={isLoading}
-      onLoadMore={() => {}}
+      onLoadMore={() => { }}
       loadingLabel="Searching…"
       isBookmarked={isBookmarked}
       onToggleBookmark={onToggleBookmark}
-      stagedStatements={stagedStatements}
-      onUnstagStatement={onUnstagStatement}
     />
   );
 };
@@ -185,8 +170,6 @@ interface RankedBrowseProps {
   isMobile: boolean;
   isBookmarked: (id: number) => boolean;
   onToggleBookmark: (id: number) => void;
-  stagedStatements?: StagedStatement[];
-  onUnstagStatement?: (tempId: string) => void;
 }
 
 const RankedBrowse: FC<RankedBrowseProps> = ({
@@ -194,8 +177,6 @@ const RankedBrowse: FC<RankedBrowseProps> = ({
   isMobile,
   isBookmarked,
   onToggleBookmark,
-  stagedStatements,
-  onUnstagStatement,
 }) => {
   const PAGE_SIZE = isMobile ? 10 : 20;
 
@@ -286,8 +267,6 @@ const RankedBrowse: FC<RankedBrowseProps> = ({
       pageIndex={pageIndex}
       isBookmarked={isBookmarked}
       onToggleBookmark={onToggleBookmark}
-      stagedStatements={stagedStatements}
-      onUnstagStatement={onUnstagStatement}
     />
   );
 };

--- a/frontend/src/components/MyStatements.tsx
+++ b/frontend/src/components/MyStatements.tsx
@@ -10,12 +10,16 @@ import useLocalStorageSet from "@/hooks/useLocalStorageSet";
 import useBlockSync from "@/hooks/useBlockSync";
 
 const MyStatements: FC = () => {
-  const { isUserVerified } = useUserVotes();
+  const userVotes = useUserVotes();
+  const { isUserVerified } = userVotes;
   const { forumContractAddress } = useForum();
   const isMobile = useIsMobile();
   const { values: authoredIds } = useLocalStorageSet("authoredStatements");
   const { has: isBookmarked, toggle: toggleBookmark } =
     useLocalStorageSet("bookmarks");
+
+  const stagedStatements = userVotes.state?.staged?.stagedStatements ?? [];
+  const unstageStatement = userVotes.unstageStatement;
 
   const PAGE_SIZE = isMobile ? 10 : 20;
   const [displayCount, setDisplayCount] = useState(PAGE_SIZE);
@@ -52,6 +56,8 @@ const MyStatements: FC = () => {
   return (
     <StatementList
       statements={displayedStatements}
+      stagedStatements={stagedStatements}
+      onUnstagStatement={unstageStatement}
       hasMore={hasMore}
       isLoading={result.isLoading}
       onLoadMore={handleLoadMore}

--- a/frontend/src/components/MyStatements.tsx
+++ b/frontend/src/components/MyStatements.tsx
@@ -18,9 +18,6 @@ const MyStatements: FC = () => {
   const { has: isBookmarked, toggle: toggleBookmark } =
     useLocalStorageSet("bookmarks");
 
-  const stagedStatements = userVotes.state?.staged?.stagedStatements ?? [];
-  const unstageStatement = userVotes.unstageStatement;
-
   const PAGE_SIZE = isMobile ? 10 : 20;
   const [displayCount, setDisplayCount] = useState(PAGE_SIZE);
   const [pageIndex, setPageIndex] = useState(0);
@@ -56,14 +53,13 @@ const MyStatements: FC = () => {
   return (
     <StatementList
       statements={displayedStatements}
-      stagedStatements={stagedStatements}
-      onUnstagStatement={unstageStatement}
       hasMore={hasMore}
       isLoading={result.isLoading}
       onLoadMore={handleLoadMore}
       pageIndex={pageIndex}
       isBookmarked={isBookmarked}
       onToggleBookmark={toggleBookmark}
+      showStagedStatements
     />
   );
 };

--- a/frontend/src/components/MySupport.tsx
+++ b/frontend/src/components/MySupport.tsx
@@ -81,6 +81,7 @@ const MySupport: FC = () => {
       pageIndex={pageIndex}
       isBookmarked={isBookmarked}
       onToggleBookmark={toggleBookmark}
+      showStagedStatements
     />
   );
 };

--- a/frontend/src/components/Root.tsx
+++ b/frontend/src/components/Root.tsx
@@ -11,7 +11,6 @@ import BottomNav from "./BottomNav";
 import WriteModal from "./WriteModal";
 import useIsMobile from "@/hooks/useIsMobile";
 import { useUserVotes } from "../state/UserVotes";
-import useLocalStorageSet from "@/hooks/useLocalStorageSet";
 import { SearchProvider } from "@/state/Search";
 
 const Root: FC = () => {
@@ -19,8 +18,6 @@ const Root: FC = () => {
   const isMobile = useIsMobile();
   const theme = useTheme();
   const { isUserVerified } = useUserVotes();
-  const { add: addAuthoredStatement } =
-    useLocalStorageSet("authoredStatements");
   const [writeModalOpen, setWriteModalOpen] = useState(false);
 
   return (
@@ -90,7 +87,6 @@ const Root: FC = () => {
             <WriteModal
               open={writeModalOpen}
               onClose={() => setWriteModalOpen(false)}
-              onStatementAdded={addAuthoredStatement}
             />
           </>
         )}

--- a/frontend/src/components/SideNav.tsx
+++ b/frontend/src/components/SideNav.tsx
@@ -17,7 +17,6 @@ import HelpOutlineIcon from "@mui/icons-material/HelpOutline";
 import CreateIcon from "@mui/icons-material/Create";
 import WriteModal from "./WriteModal";
 import { useUserVotes } from "../state/UserVotes";
-import useLocalStorageSet from "@/hooks/useLocalStorageSet";
 import UserProfilePill from "./UserProfilePill";
 import { useAccount, useDisconnect } from "wagmi";
 import { AccountMenu } from "./UserProfileMenu";
@@ -37,8 +36,6 @@ const SideNav: FC = () => {
   const { isUserVerified } = useUserVotes();
   const { address } = useAccount();
   const { disconnect: doDisconnect } = useDisconnect();
-  const { add: addAuthoredStatement } =
-    useLocalStorageSet("authoredStatements");
 
   const [writeModalOpen, setWriteModalOpen] = useState(false);
   const [menuAnchorEl, setMenuAnchorEl] = useState<null | HTMLElement>(null);
@@ -116,7 +113,6 @@ const SideNav: FC = () => {
       <WriteModal
         open={writeModalOpen}
         onClose={() => setWriteModalOpen(false)}
-        onStatementAdded={addAuthoredStatement}
       />
     </>
   );

--- a/frontend/src/components/StagedStatementCard.tsx
+++ b/frontend/src/components/StagedStatementCard.tsx
@@ -1,0 +1,57 @@
+import { FC } from "react";
+import { Chip, IconButton, Stack } from "@mui/material";
+import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
+
+import { StagedStatement } from "../state/UserVotes";
+import VoteToggle from "./VoteToggle";
+import StatementCardShell from "./StatementCardShell";
+
+interface StagedStatementCardProps {
+  staged: StagedStatement;
+  onUnstage?: (tempId: string) => void;
+  onUpdateSupport?: (tempId: string, newSupport: number) => void;
+}
+
+const StagedStatementCard: FC<StagedStatementCardProps> = ({
+  staged,
+  onUnstage,
+  onUpdateSupport,
+}) => {
+  const statsSlot = (
+    <Stack direction="row" alignItems="center" spacing={1} sx={{ mt: 0.5 }}>
+      <Chip label="Pending" size="small" color="warning" variant="outlined" />
+      {onUnstage && (
+        <IconButton
+          size="small"
+          onClick={() => onUnstage(staged.tempId)}
+          aria-label="Remove staged statement"
+          sx={{ p: 0.25 }}
+        >
+          <DeleteOutlineIcon fontSize="small" color="action" />
+        </IconButton>
+      )}
+    </Stack>
+  );
+
+  const voteControls = onUpdateSupport ? (
+    <VoteToggle
+      userSupport={staged.initialSupport}
+      uncommittedSupport={true}
+      onUserVoteChange={(newSupport) =>
+        onUpdateSupport(staged.tempId, newSupport)
+      }
+      direction="vertical"
+    />
+  ) : undefined;
+
+  return (
+    <StatementCardShell
+      text={staged.text}
+      statsSlot={statsSlot}
+      voteControls={voteControls}
+      sx={{ opacity: 0.85 }}
+    />
+  );
+};
+
+export default StagedStatementCard;

--- a/frontend/src/components/StatementCard.tsx
+++ b/frontend/src/components/StatementCard.tsx
@@ -1,5 +1,5 @@
 import { FC, useEffect } from "react";
-import { Card, IconButton, Stack, Typography } from "@mui/material";
+import { IconButton, Stack, Typography } from "@mui/material";
 import BookmarkIcon from "@mui/icons-material/Bookmark";
 import BookmarkBorderIcon from "@mui/icons-material/BookmarkBorder";
 import ArrowUpwardIcon from "@mui/icons-material/ArrowUpward";
@@ -8,9 +8,9 @@ import LandscapeIcon from "@mui/icons-material/Landscape";
 
 import { useUserVotes } from "../state/UserVotes";
 import VoteToggle from "./VoteToggle";
+import StatementCardShell from "./StatementCardShell";
 import { useBlockNumber, useReadContract } from "wagmi";
 import { useForum, FORUM_ABI } from "../state/Forum";
-import useIsMobile from "@/hooks/useIsMobile";
 
 const LOOK_BACK_BLOCKS = BigInt(1);
 
@@ -79,7 +79,6 @@ export const StatementCard: FC<StatementCardProps> = ({
     hasAdjustment,
   } = useUserVotes();
   const { forumContractAddress } = useForum();
-  const isMobile = useIsMobile();
 
   // Watch for new blocks
   const { data: blockNumber } = useBlockNumber({ watch: true });
@@ -140,172 +139,113 @@ export const StatementCard: FC<StatementCardProps> = ({
 
   const globalSupport = Number(statement.support);
 
-  return (
-    <Card
+  const leftSlot = currentRank !== null ? (
+    <Typography
+      variant="h4"
       sx={{
-        p: 2,
-        transition: "box-shadow 0.2s ease",
-        "&:hover": {
-          boxShadow: 3,
-        },
+        fontWeight: 700,
+        fontSize: rankFontSize(currentRank),
+        lineHeight: 1.1,
+        color: rankColor(currentRank) ?? "text.primary",
       }}
     >
-      <Stack direction="row" spacing={2}>
-        {/* Left column: rank */}
-        <Stack
-          alignItems="center"
-          justifyContent="center"
-          sx={{ width: 48, minWidth: 48, flexShrink: 0 }}
-        >
-          {currentRank !== null ? (
-            <Typography
-              variant="h4"
-              sx={{
-                fontWeight: 700,
-                fontSize: rankFontSize(currentRank),
-                lineHeight: 1.1,
-                color: rankColor(currentRank) ?? "text.primary",
-              }}
-            >
-              {currentRank}
-            </Typography>
-          ) : (
-            <Typography
-              variant="caption"
-              sx={{
-                fontWeight: 600,
-                fontSize: "0.6rem",
-                lineHeight: 1.2,
-                color: "text.disabled",
-                textAlign: "center",
-                textTransform: "uppercase",
-                letterSpacing: "0.04em",
-              }}
-            >
-              Not
-              <br />
-              Ranked
-            </Typography>
-          )}
-        </Stack>
+      {currentRank}
+    </Typography>
+  ) : (
+    <Typography
+      variant="caption"
+      sx={{
+        fontWeight: 600,
+        fontSize: "0.6rem",
+        lineHeight: 1.2,
+        color: "text.disabled",
+        textAlign: "center",
+        textTransform: "uppercase",
+        letterSpacing: "0.04em",
+      }}
+    >
+      Not
+      <br />
+      Ranked
+    </Typography>
+  );
 
-        {/* Middle column: content */}
-        <Stack
-          spacing={1.5}
-          sx={{ flex: 1, minWidth: 0 }}
-          justifyContent="space-between"
-        >
-          {/* Statement text */}
-          <Typography variant="h6" sx={{ fontWeight: 500 }}>
-            {statement.text}
+  const statsSlot = (
+    <Stack direction="row" alignItems="center" spacing={2} sx={{ mt: 0.5 }}>
+      <Typography variant="body2" sx={{ fontWeight: 600, color: "primary.main" }}>
+        {formatSupport(globalSupport)}
+      </Typography>
+
+      <Stack direction="row" alignItems="center" spacing={0.25}>
+        {rankChange === null || rankChange === 0 ? (
+          <Typography variant="body2" color="text.disabled">
+            —
           </Typography>
-
-          {/* Vote controls — inline on mobile only */}
-          {isUserVerified && isMobile && (
-            <VoteToggle
-              userSupport={userSupport}
-              uncommittedSupport={hasUncommittedSupport}
-              onUserVoteChange={handleSupportChange}
-              direction="horizontal"
-            />
-          )}
-
-          {/* Bottom stats row */}
-          <Stack
-            direction="row"
-            alignItems="center"
-            spacing={2}
-            sx={{ mt: 0.5 }}
-          >
-            {/* Global support (blue) */}
-            <Typography
-              variant="body2"
-              sx={{ fontWeight: 600, color: "primary.main" }}
-            >
-              {formatSupport(globalSupport)}
+        ) : rankChange > 0 ? (
+          <>
+            <ArrowUpwardIcon sx={{ fontSize: 16, color: "success.main" }} />
+            <Typography variant="body2" sx={{ fontWeight: 600, color: "success.main" }}>
+              {rankChange}
             </Typography>
-
-            {/* Rank change */}
-            <Stack direction="row" alignItems="center" spacing={0.25}>
-              {rankChange === null || rankChange === 0 ? (
-                <Typography variant="body2" color="text.disabled">
-                  —
-                </Typography>
-              ) : rankChange > 0 ? (
-                <>
-                  <ArrowUpwardIcon
-                    sx={{ fontSize: 16, color: "success.main" }}
-                  />
-                  <Typography
-                    variant="body2"
-                    sx={{ fontWeight: 600, color: "success.main" }}
-                  >
-                    {rankChange}
-                  </Typography>
-                </>
-              ) : (
-                <>
-                  <ArrowDownwardIcon
-                    sx={{ fontSize: 16, color: "error.main" }}
-                  />
-                  <Typography
-                    variant="body2"
-                    sx={{ fontWeight: 600, color: "error.main" }}
-                  >
-                    {Math.abs(rankChange)}
-                  </Typography>
-                </>
-              )}
-            </Stack>
-
-            {/* Peak rank */}
-            {peakRank !== null && (
-              <Stack direction="row" alignItems="center" spacing={0.5}>
-                <LandscapeIcon sx={{ fontSize: 18, color: "text.secondary" }} />
-                <Typography variant="body2" color="text.secondary">
-                  {peakRank}
-                </Typography>
-              </Stack>
-            )}
-
-            {/* Spacer pushes bookmark to the right */}
-            <Stack sx={{ flexGrow: 1 }} />
-
-            {/* Bookmark */}
-            {onToggleBookmark && (
-              <IconButton
-                size="small"
-                onClick={() => onToggleBookmark(Number(statement.id))}
-                aria-label={isBookmarked ? "Remove bookmark" : "Bookmark"}
-                sx={{ p: 0 }}
-              >
-                {isBookmarked ? (
-                  <BookmarkIcon sx={{ fontSize: 22 }} />
-                ) : (
-                  <BookmarkBorderIcon sx={{ fontSize: 22 }} />
-                )}
-              </IconButton>
-            )}
-          </Stack>
-        </Stack>
-
-        {/* Right column: vertical vote controls — desktop only */}
-        {isUserVerified && !isMobile && (
-          <Stack
-            alignItems="center"
-            justifyContent="center"
-            sx={{ flexShrink: 0, ml: "auto" }}
-          >
-            <VoteToggle
-              userSupport={userSupport}
-              uncommittedSupport={hasUncommittedSupport}
-              onUserVoteChange={handleSupportChange}
-              direction="vertical"
-            />
-          </Stack>
+          </>
+        ) : (
+          <>
+            <ArrowDownwardIcon sx={{ fontSize: 16, color: "error.main" }} />
+            <Typography variant="body2" sx={{ fontWeight: 600, color: "error.main" }}>
+              {Math.abs(rankChange)}
+            </Typography>
+          </>
         )}
       </Stack>
-    </Card>
+
+      {peakRank !== null && (
+        <Stack direction="row" alignItems="center" spacing={0.5}>
+          <LandscapeIcon sx={{ fontSize: 18, color: "text.secondary" }} />
+          <Typography variant="body2" color="text.secondary">
+            {peakRank}
+          </Typography>
+        </Stack>
+      )}
+
+      <Stack sx={{ flexGrow: 1 }} />
+
+      {onToggleBookmark && (
+        <IconButton
+          size="small"
+          onClick={() => onToggleBookmark(Number(statement.id))}
+          aria-label={isBookmarked ? "Remove bookmark" : "Bookmark"}
+          sx={{ p: 0 }}
+        >
+          {isBookmarked ? (
+            <BookmarkIcon sx={{ fontSize: 22 }} />
+          ) : (
+            <BookmarkBorderIcon sx={{ fontSize: 22 }} />
+          )}
+        </IconButton>
+      )}
+    </Stack>
+  );
+
+  const voteControls = isUserVerified ? (
+    <VoteToggle
+      userSupport={userSupport}
+      uncommittedSupport={hasUncommittedSupport}
+      onUserVoteChange={handleSupportChange}
+      direction="vertical"
+    />
+  ) : undefined;
+
+  return (
+    <StatementCardShell
+      leftSlot={leftSlot}
+      text={statement.text}
+      statsSlot={statsSlot}
+      voteControls={voteControls}
+      sx={{
+        transition: "box-shadow 0.2s ease",
+        "&:hover": { boxShadow: 3 },
+      }}
+    />
   );
 };
 

--- a/frontend/src/components/StatementCard.tsx
+++ b/frontend/src/components/StatementCard.tsx
@@ -139,40 +139,44 @@ export const StatementCard: FC<StatementCardProps> = ({
 
   const globalSupport = Number(statement.support);
 
-  const leftSlot = currentRank !== null ? (
-    <Typography
-      variant="h4"
-      sx={{
-        fontWeight: 700,
-        fontSize: rankFontSize(currentRank),
-        lineHeight: 1.1,
-        color: rankColor(currentRank) ?? "text.primary",
-      }}
-    >
-      {currentRank}
-    </Typography>
-  ) : (
-    <Typography
-      variant="caption"
-      sx={{
-        fontWeight: 600,
-        fontSize: "0.6rem",
-        lineHeight: 1.2,
-        color: "text.disabled",
-        textAlign: "center",
-        textTransform: "uppercase",
-        letterSpacing: "0.04em",
-      }}
-    >
-      Not
-      <br />
-      Ranked
-    </Typography>
-  );
+  const leftSlot =
+    currentRank !== null ? (
+      <Typography
+        variant="h4"
+        sx={{
+          fontWeight: 700,
+          fontSize: rankFontSize(currentRank),
+          lineHeight: 1.1,
+          color: rankColor(currentRank) ?? "text.primary",
+        }}
+      >
+        {currentRank}
+      </Typography>
+    ) : (
+      <Typography
+        variant="caption"
+        sx={{
+          fontWeight: 600,
+          fontSize: "0.6rem",
+          lineHeight: 1.2,
+          color: "text.disabled",
+          textAlign: "center",
+          textTransform: "uppercase",
+          letterSpacing: "0.04em",
+        }}
+      >
+        Not
+        <br />
+        Ranked
+      </Typography>
+    );
 
   const statsSlot = (
     <Stack direction="row" alignItems="center" spacing={2} sx={{ mt: 0.5 }}>
-      <Typography variant="body2" sx={{ fontWeight: 600, color: "primary.main" }}>
+      <Typography
+        variant="body2"
+        sx={{ fontWeight: 600, color: "primary.main" }}
+      >
         {formatSupport(globalSupport)}
       </Typography>
 
@@ -184,14 +188,20 @@ export const StatementCard: FC<StatementCardProps> = ({
         ) : rankChange > 0 ? (
           <>
             <ArrowUpwardIcon sx={{ fontSize: 16, color: "success.main" }} />
-            <Typography variant="body2" sx={{ fontWeight: 600, color: "success.main" }}>
+            <Typography
+              variant="body2"
+              sx={{ fontWeight: 600, color: "success.main" }}
+            >
               {rankChange}
             </Typography>
           </>
         ) : (
           <>
             <ArrowDownwardIcon sx={{ fontSize: 16, color: "error.main" }} />
-            <Typography variant="body2" sx={{ fontWeight: 600, color: "error.main" }}>
+            <Typography
+              variant="body2"
+              sx={{ fontWeight: 600, color: "error.main" }}
+            >
               {Math.abs(rankChange)}
             </Typography>
           </>

--- a/frontend/src/components/StatementCardShell.tsx
+++ b/frontend/src/components/StatementCardShell.tsx
@@ -1,0 +1,86 @@
+import { FC, ReactNode } from "react";
+import { Card, Stack, SxProps, Theme, Typography } from "@mui/material";
+import useIsMobile from "@/hooks/useIsMobile";
+
+interface StatementCardShellProps {
+  /**
+   * Content for the fixed-width left column (rank number, "Not Ranked" label,
+   * or empty for staged statements).
+   */
+  leftSlot?: ReactNode;
+  /** Main statement text. */
+  text: string;
+  /**
+   * Bottom stats/actions row displayed below the text.
+   * Different for on-chain statements (support, rank change) vs staged (Pending
+   * chip + delete).
+   */
+  statsSlot: ReactNode;
+  /**
+   * Vote controls (VoteToggle). The shell handles responsive placement:
+   * inline below the text on mobile, in the right column on desktop.
+   */
+  voteControls?: ReactNode;
+  sx?: SxProps<Theme>;
+}
+
+/**
+ * Shared three-column card layout used by both StatementCard and
+ * StagedStatementCard.
+ *
+ * Layout:
+ *   [ leftSlot (48px) ] [ text / mobileVote / statsSlot ] [ desktopVote ]
+ */
+const StatementCardShell: FC<StatementCardShellProps> = ({
+  leftSlot,
+  text,
+  statsSlot,
+  voteControls,
+  sx,
+}) => {
+  const isMobile = useIsMobile();
+
+  return (
+    <Card sx={{ p: 2, ...sx }}>
+      <Stack direction="row" spacing={2}>
+        {/* Left column: rank or placeholder */}
+        <Stack
+          alignItems="center"
+          justifyContent="center"
+          sx={{ width: 48, minWidth: 48, flexShrink: 0 }}
+        >
+          {leftSlot}
+        </Stack>
+
+        {/* Middle column: text + inline vote (mobile) + stats */}
+        <Stack
+          spacing={1.5}
+          sx={{ flex: 1, minWidth: 0 }}
+          justifyContent="space-between"
+        >
+          <Typography variant="h6" sx={{ fontWeight: 500 }}>
+            {text}
+          </Typography>
+
+          {/* Inline vote controls on mobile */}
+          {isMobile && voteControls}
+
+          {statsSlot}
+        </Stack>
+
+        {/* Right column: vertical vote controls on desktop */}
+        {!isMobile && voteControls && (
+          <Stack
+            alignItems="center"
+            justifyContent="center"
+            sx={{ flexShrink: 0, ml: "auto" }}
+          >
+            {voteControls}
+          </Stack>
+        )}
+      </Stack>
+    </Card>
+  );
+};
+
+export default StatementCardShell;

--- a/frontend/src/components/StatementList.tsx
+++ b/frontend/src/components/StatementList.tsx
@@ -2,17 +2,14 @@ import { FC, useEffect, useRef } from "react";
 import { Statement } from "../types";
 import {
   Box,
-  Card,
-  Chip,
   CircularProgress,
-  IconButton,
   Stack,
   Typography,
   useTheme,
 } from "@mui/material";
-import CloseIcon from "@mui/icons-material/Close";
 import StatementCard from "./StatementCard";
-import { type StagedStatement } from "../state/UserVotes";
+import StagedStatementCard from "./StagedStatementCard";
+import { useUserVotes } from "../state/UserVotes";
 
 type StatementListProps = {
   statements: Statement[];
@@ -25,10 +22,8 @@ type StatementListProps = {
   loadingLabel?: string;
   isBookmarked?: (statementId: number) => boolean;
   onToggleBookmark?: (statementId: number) => void;
-  /** Staged (not yet committed) statements to render above the on-chain list. */
-  stagedStatements?: StagedStatement[];
-  /** Called when the user removes a staged statement. */
-  onUnstagStatement?: (tempId: string) => void;
+  /** When true, staged (uncommitted) statements are shown at the top. */
+  showStagedStatements?: boolean;
 };
 
 const StatementList: FC<StatementListProps> = ({
@@ -40,11 +35,15 @@ const StatementList: FC<StatementListProps> = ({
   loadingLabel = "Loading more statements\u2026",
   isBookmarked,
   onToggleBookmark,
-  stagedStatements,
-  onUnstagStatement,
+  showStagedStatements = false,
 }) => {
   const theme = useTheme();
   const sentinelRef = useRef<HTMLDivElement>(null);
+  const userVotes = useUserVotes();
+
+  const stagedStatements = userVotes.state?.staged?.stagedStatements ?? [];
+  const unstageStatement = userVotes.unstageStatement;
+  const updateStagedInitialSupport = userVotes.updateStagedInitialSupport;
 
   useEffect(() => {
     const sentinel = sentinelRef.current;
@@ -80,7 +79,8 @@ const StatementList: FC<StatementListProps> = ({
     };
   }, [hasMore, isLoading, onLoadMore]);
 
-  const hasStagedStatements = stagedStatements && stagedStatements.length > 0;
+  const hasStagedStatements =
+    showStagedStatements && stagedStatements && stagedStatements.length > 0;
 
   if (!isLoading && statements.length === 0 && !hasStagedStatements) {
     return (
@@ -105,49 +105,12 @@ const StatementList: FC<StatementListProps> = ({
         {/* Staged (pending) statements */}
         {hasStagedStatements &&
           stagedStatements.map((staged) => (
-            <Card
+            <StagedStatementCard
               key={`staged-${staged.tempId}`}
-              sx={{
-                p: 2,
-                opacity: 0.85,
-                border: "1px dashed",
-                borderColor: "warning.main",
-              }}
-            >
-              <Stack
-                direction="row"
-                alignItems="center"
-                justifyContent="space-between"
-              >
-                <Stack spacing={0.5} sx={{ flex: 1, minWidth: 0 }}>
-                  <Stack direction="row" alignItems="center" spacing={1}>
-                    <Chip
-                      label="Pending"
-                      size="small"
-                      color="warning"
-                      variant="outlined"
-                    />
-                    {staged.initialSupport !== 0 && (
-                      <Typography variant="caption" color="text.secondary">
-                        Initial support: {staged.initialSupport}
-                      </Typography>
-                    )}
-                  </Stack>
-                  <Typography variant="h6" sx={{ fontWeight: 500 }}>
-                    {staged.text}
-                  </Typography>
-                </Stack>
-                {onUnstagStatement && (
-                  <IconButton
-                    size="small"
-                    onClick={() => onUnstagStatement(staged.tempId)}
-                    aria-label="Remove staged statement"
-                  >
-                    <CloseIcon fontSize="small" />
-                  </IconButton>
-                )}
-              </Stack>
-            </Card>
+              staged={staged}
+              onUnstage={unstageStatement}
+              onUpdateSupport={updateStagedInitialSupport}
+            />
           ))}
 
         {/* On-chain statements */}

--- a/frontend/src/components/StatementList.tsx
+++ b/frontend/src/components/StatementList.tsx
@@ -2,12 +2,17 @@ import { FC, useEffect, useRef } from "react";
 import { Statement } from "../types";
 import {
   Box,
+  Card,
+  Chip,
   CircularProgress,
+  IconButton,
   Stack,
   Typography,
   useTheme,
 } from "@mui/material";
+import CloseIcon from "@mui/icons-material/Close";
 import StatementCard from "./StatementCard";
+import { type StagedStatement } from "../state/UserVotes";
 
 type StatementListProps = {
   statements: Statement[];
@@ -20,6 +25,10 @@ type StatementListProps = {
   loadingLabel?: string;
   isBookmarked?: (statementId: number) => boolean;
   onToggleBookmark?: (statementId: number) => void;
+  /** Staged (not yet committed) statements to render above the on-chain list. */
+  stagedStatements?: StagedStatement[];
+  /** Called when the user removes a staged statement. */
+  onUnstagStatement?: (tempId: string) => void;
 };
 
 const StatementList: FC<StatementListProps> = ({
@@ -31,6 +40,8 @@ const StatementList: FC<StatementListProps> = ({
   loadingLabel = "Loading more statements\u2026",
   isBookmarked,
   onToggleBookmark,
+  stagedStatements,
+  onUnstagStatement,
 }) => {
   const theme = useTheme();
   const sentinelRef = useRef<HTMLDivElement>(null);
@@ -69,7 +80,9 @@ const StatementList: FC<StatementListProps> = ({
     };
   }, [hasMore, isLoading, onLoadMore]);
 
-  if (!isLoading && statements.length === 0) {
+  const hasStagedStatements = stagedStatements && stagedStatements.length > 0;
+
+  if (!isLoading && statements.length === 0 && !hasStagedStatements) {
     return (
       <Box
         sx={{
@@ -89,6 +102,55 @@ const StatementList: FC<StatementListProps> = ({
   return (
     <>
       <Stack spacing={1}>
+        {/* Staged (pending) statements */}
+        {hasStagedStatements &&
+          stagedStatements.map((staged) => (
+            <Card
+              key={`staged-${staged.tempId}`}
+              sx={{
+                p: 2,
+                opacity: 0.85,
+                border: "1px dashed",
+                borderColor: "warning.main",
+              }}
+            >
+              <Stack
+                direction="row"
+                alignItems="center"
+                justifyContent="space-between"
+              >
+                <Stack spacing={0.5} sx={{ flex: 1, minWidth: 0 }}>
+                  <Stack direction="row" alignItems="center" spacing={1}>
+                    <Chip
+                      label="Pending"
+                      size="small"
+                      color="warning"
+                      variant="outlined"
+                    />
+                    {staged.initialSupport !== 0 && (
+                      <Typography variant="caption" color="text.secondary">
+                        Initial support: {staged.initialSupport}
+                      </Typography>
+                    )}
+                  </Stack>
+                  <Typography variant="h6" sx={{ fontWeight: 500 }}>
+                    {staged.text}
+                  </Typography>
+                </Stack>
+                {onUnstagStatement && (
+                  <IconButton
+                    size="small"
+                    onClick={() => onUnstagStatement(staged.tempId)}
+                    aria-label="Remove staged statement"
+                  >
+                    <CloseIcon fontSize="small" />
+                  </IconButton>
+                )}
+              </Stack>
+            </Card>
+          ))}
+
+        {/* On-chain statements */}
         {statements?.map((stmt) => (
           <StatementCard
             key={`stmt-${Number(stmt.id)}`}

--- a/frontend/src/components/UserProfileMenu.tsx
+++ b/frontend/src/components/UserProfileMenu.tsx
@@ -111,7 +111,7 @@ export interface AccountDrawerProps {
   disconnect: () => void;
   username?: string;
   avatar?: string | null;
-  commitSupport: () => void | Promise<void>;
+  commitChanges: () => void | Promise<void>;
   hasStagedChanges: boolean;
   commitBusy?: boolean;
 }
@@ -124,7 +124,7 @@ export const AccountDrawer: React.FC<AccountDrawerProps> = ({
   disconnect,
   username,
   avatar,
-  commitSupport,
+  commitChanges,
   hasStagedChanges,
   commitBusy = false,
 }) => {
@@ -134,7 +134,7 @@ export const AccountDrawer: React.FC<AccountDrawerProps> = ({
   };
 
   const handleCommit = () => {
-    void commitSupport();
+    void commitChanges();
     onClose();
   };
 

--- a/frontend/src/components/UserProfilePill.tsx
+++ b/frontend/src/components/UserProfilePill.tsx
@@ -63,7 +63,7 @@ const UserProfilePill: React.FC<UserProfilePillProps> = ({ onOpenMenu }) => {
     ? userVotes.state?.commitStatus !== undefined &&
       userVotes.state?.commitStatus !== "idle"
     : false;
-  const commitSupport = isUserVerified ? userVotes.commitSupport : () => {};
+  const commitChanges = isUserVerified ? userVotes.commitChanges : () => {};
 
   const showCommit = credits !== null;
 
@@ -107,7 +107,7 @@ const UserProfilePill: React.FC<UserProfilePillProps> = ({ onOpenMenu }) => {
             size="small"
             onClick={(e) => {
               e.stopPropagation();
-              void commitSupport();
+              void commitChanges();
             }}
             disabled={!hasStagedChanges || commitBusy}
             sx={{

--- a/frontend/src/components/WriteModal.tsx
+++ b/frontend/src/components/WriteModal.tsx
@@ -7,8 +7,7 @@ import {
   Typography,
 } from "@mui/material";
 import { FC, useCallback, useState } from "react";
-import { useReadContract, useWriteContract } from "wagmi";
-import { FORUM_ABI, useForum } from "../state/Forum";
+import { useUserVotes } from "../state/UserVotes";
 
 const MAX_STATEMENT_LENGTH = 280;
 
@@ -28,50 +27,19 @@ const style = {
 type WriteModalProps = {
   open: boolean;
   onClose: () => void;
-  onStatementAdded?: (statementId: number) => void;
 };
 
-const WriteModal: FC<WriteModalProps> = ({
-  open,
-  onClose,
-  onStatementAdded,
-}) => {
-  const { writeContract } = useWriteContract();
+const WriteModal: FC<WriteModalProps> = ({ open, onClose }) => {
   const [text, setText] = useState("");
-  const { forumContractAddress } = useForum();
-
-  // Read the current statement count so we know the ID of the next statement
-  const { data: statementCount } = useReadContract({
-    address: forumContractAddress,
-    abi: FORUM_ABI,
-    functionName: "statementCount",
-  });
+  const { isUserVerified, stageStatement } = useUserVotes();
 
   const submitStatement = useCallback(() => {
-    if (text.length > 0) {
-      const nextId =
-        statementCount !== undefined ? Number(statementCount) : undefined;
-      writeContract({
-        address: forumContractAddress,
-        abi: FORUM_ABI,
-        functionName: "addStatement",
-        args: [text],
-      });
-      if (nextId !== undefined && onStatementAdded) {
-        onStatementAdded(nextId);
-      }
+    if (text.length > 0 && isUserVerified && stageStatement) {
+      stageStatement(text);
       setText("");
       onClose();
     }
-  }, [
-    text,
-    writeContract,
-    setText,
-    onClose,
-    forumContractAddress,
-    statementCount,
-    onStatementAdded,
-  ]);
+  }, [text, isUserVerified, stageStatement, setText, onClose]);
 
   const updateText = useCallback(
     (textVal: string) => {
@@ -122,7 +90,7 @@ const WriteModal: FC<WriteModalProps> = ({
           </Typography>
           <Button onClick={onClose}> Cancel </Button>
           <Button disabled={text.length === 0} onClick={submitStatement}>
-            Submit
+            Create
           </Button>
         </Stack>
       </Box>

--- a/frontend/src/contracts/abis/Forum.ts
+++ b/frontend/src/contracts/abis/Forum.ts
@@ -622,6 +622,19 @@ export default [
     "type": "function"
   },
   {
+    "inputs": [],
+    "name": "getCurrentStep",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "internalType": "uint256",

--- a/frontend/src/contracts/abis/Forum.ts
+++ b/frontend/src/contracts/abis/Forum.ts
@@ -3,638 +3,820 @@
 
 export default [
   {
-    inputs: [
+    "inputs": [
       {
-        internalType: "contract AOurVoiceRegistry",
-        name: "_ourVoiceRegistry",
-        type: "address",
+        "internalType": "contract AOurVoiceRegistry",
+        "name": "_ourVoiceRegistry",
+        "type": "address"
       },
       {
-        internalType: "string",
-        name: "_nationality",
-        type: "string",
+        "internalType": "string",
+        "name": "_nationality",
+        "type": "string"
       },
       {
-        internalType: "uint256",
-        name: "_maxRankedStatements",
-        type: "uint256",
+        "internalType": "uint256",
+        "name": "_maxRankedStatements",
+        "type": "uint256"
       },
+      {
+        "internalType": "uint256",
+        "name": "_stepDurationSeconds",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_engagementWindowSeconds",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_maxStatementLength",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_userCreditAllowancePerStep",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_userStartingCredits",
+        "type": "uint256"
+      },
+      {
+        "internalType": "int256",
+        "name": "_minStatementSupportToRank",
+        "type": "int256"
+      }
     ],
-    stateMutability: "nonpayable",
-    type: "constructor",
+    "stateMutability": "nonpayable",
+    "type": "constructor"
   },
   {
-    inputs: [
+    "inputs": [
       {
-        internalType: "uint256",
-        name: "available",
-        type: "uint256",
-      },
-      {
-        internalType: "int256",
-        name: "required",
-        type: "int256",
-      },
+        "internalType": "address",
+        "name": "target",
+        "type": "address"
+      }
     ],
-    name: "InsufficientCredits",
-    type: "error",
+    "name": "AddressEmptyCode",
+    "type": "error"
   },
   {
-    inputs: [
+    "inputs": [],
+    "name": "FailedCall",
+    "type": "error"
+  },
+  {
+    "inputs": [
       {
-        internalType: "uint256",
-        name: "statementId",
-        type: "uint256",
+        "internalType": "uint256",
+        "name": "available",
+        "type": "uint256"
       },
+      {
+        "internalType": "int256",
+        "name": "required",
+        "type": "int256"
+      }
     ],
-    name: "InvalidStatementId",
-    type: "error",
+    "name": "InsufficientCredits",
+    "type": "error"
   },
   {
-    inputs: [],
-    name: "NotMember",
-    type: "error",
-  },
-  {
-    inputs: [
+    "inputs": [
       {
-        internalType: "uint256",
-        name: "rank",
-        type: "uint256",
-      },
-      {
-        internalType: "uint256",
-        name: "rankedCount",
-        type: "uint256",
-      },
+        "internalType": "uint256",
+        "name": "statementId",
+        "type": "uint256"
+      }
     ],
-    name: "RankOutOfBounds",
-    type: "error",
+    "name": "InvalidStatementId",
+    "type": "error"
   },
   {
-    inputs: [
+    "inputs": [],
+    "name": "NotMember",
+    "type": "error"
+  },
+  {
+    "inputs": [
       {
-        internalType: "uint256",
-        name: "start",
-        type: "uint256",
+        "internalType": "uint256",
+        "name": "rank",
+        "type": "uint256"
       },
       {
-        internalType: "uint256",
-        name: "statementCount",
-        type: "uint256",
-      },
+        "internalType": "uint256",
+        "name": "rankedCount",
+        "type": "uint256"
+      }
     ],
-    name: "StartOutOfBounds",
-    type: "error",
+    "name": "RankOutOfBounds",
+    "type": "error"
   },
   {
-    inputs: [
+    "inputs": [
       {
-        internalType: "uint256",
-        name: "length",
-        type: "uint256",
+        "internalType": "uint256",
+        "name": "expected",
+        "type": "uint256"
       },
       {
-        internalType: "uint256",
-        name: "maxLength",
-        type: "uint256",
-      },
+        "internalType": "uint256",
+        "name": "actual",
+        "type": "uint256"
+      }
     ],
-    name: "StatementTooLong",
-    type: "error",
+    "name": "StaleStep",
+    "type": "error"
   },
   {
-    inputs: [
+    "inputs": [
       {
-        internalType: "address",
-        name: "user",
-        type: "address",
+        "internalType": "uint256",
+        "name": "start",
+        "type": "uint256"
       },
+      {
+        "internalType": "uint256",
+        "name": "statementCount",
+        "type": "uint256"
+      }
     ],
-    name: "UserNotRegistered",
-    type: "error",
+    "name": "StartOutOfBounds",
+    "type": "error"
   },
   {
-    anonymous: false,
-    inputs: [
+    "inputs": [
       {
-        indexed: true,
-        internalType: "uint256",
-        name: "id",
-        type: "uint256",
+        "internalType": "uint256",
+        "name": "length",
+        "type": "uint256"
       },
       {
-        indexed: false,
-        internalType: "string",
-        name: "statement",
-        type: "string",
-      },
+        "internalType": "uint256",
+        "name": "maxLength",
+        "type": "uint256"
+      }
     ],
-    name: "StatementAdded",
-    type: "event",
+    "name": "StatementTooLong",
+    "type": "error"
   },
   {
-    stateMutability: "nonpayable",
-    type: "fallback",
-  },
-  {
-    inputs: [],
-    name: "MAX_RANKED_STATEMENTS",
-    outputs: [
+    "inputs": [
       {
-        internalType: "uint256",
-        name: "",
-        type: "uint256",
+        "internalType": "uint256",
+        "name": "fromTimestamp",
+        "type": "uint256"
       },
+      {
+        "internalType": "uint256",
+        "name": "toTimestamp",
+        "type": "uint256"
+      }
     ],
-    stateMutability: "view",
-    type: "function",
+    "name": "TimestampOrderInvalid",
+    "type": "error"
   },
   {
-    inputs: [],
-    name: "MAX_STATEMENT_LENGTH",
-    outputs: [
+    "inputs": [
       {
-        internalType: "uint256",
-        name: "",
-        type: "uint256",
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      }
+    ],
+    "name": "UserNotRegistered",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
       },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "statement",
+        "type": "string"
+      }
     ],
-    stateMutability: "view",
-    type: "function",
+    "name": "StatementAdded",
+    "type": "event"
   },
   {
-    inputs: [],
-    name: "MIN_STATEMENT_SUPPORT_TO_RANK",
-    outputs: [
+    "anonymous": false,
+    "inputs": [
       {
-        internalType: "int256",
-        name: "",
-        type: "int256",
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "statementId",
+        "type": "uint256"
+      }
+    ],
+    "name": "StatementEngaged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "statementId",
+        "type": "uint256"
       },
-    ],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [],
-    name: "USER_CREDIT_ALLOWANCE_PER_STEP",
-    outputs: [
       {
-        internalType: "uint256",
-        name: "",
-        type: "uint256",
+        "indexed": false,
+        "internalType": "int256",
+        "name": "previousRank",
+        "type": "int256"
       },
+      {
+        "indexed": false,
+        "internalType": "int256",
+        "name": "newRank",
+        "type": "int256"
+      }
     ],
-    stateMutability: "view",
-    type: "function",
+    "name": "StatementRankChanged",
+    "type": "event"
   },
   {
-    inputs: [],
-    name: "USER_STARTING_CREDITS",
-    outputs: [
+    "stateMutability": "nonpayable",
+    "type": "fallback"
+  },
+  {
+    "inputs": [
       {
-        internalType: "uint256",
-        name: "",
-        type: "uint256",
+        "internalType": "string",
+        "name": "_statementText",
+        "type": "string"
       },
+      {
+        "internalType": "int256",
+        "name": "_initialSupport",
+        "type": "int256"
+      }
     ],
-    stateMutability: "view",
-    type: "function",
+    "name": "addStatement",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
   },
   {
-    inputs: [
+    "inputs": [
       {
-        internalType: "string",
-        name: "_statementText",
-        type: "string",
-      },
-    ],
-    name: "addStatement",
-    outputs: [],
-    stateMutability: "nonpayable",
-    type: "function",
-  },
-  {
-    inputs: [
-      {
-        components: [
+        "components": [
           {
-            internalType: "uint256",
-            name: "statementId",
-            type: "uint256",
+            "internalType": "uint256",
+            "name": "statementId",
+            "type": "uint256"
           },
           {
-            internalType: "int256",
-            name: "value",
-            type: "int256",
-          },
+            "internalType": "int256",
+            "name": "value",
+            "type": "int256"
+          }
         ],
-        internalType: "struct Forum.SupportAdjustment[]",
-        name: "_supportAdjustments",
-        type: "tuple[]",
-      },
+        "internalType": "struct Forum.SupportAdjustment[]",
+        "name": "_supportAdjustments",
+        "type": "tuple[]"
+      }
     ],
-    name: "adjustSupport",
-    outputs: [],
-    stateMutability: "nonpayable",
-    type: "function",
+    "name": "adjustSupport",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
   },
   {
-    inputs: [
+    "inputs": [],
+    "name": "engagementWindowSeconds",
+    "outputs": [
       {
-        internalType: "uint256",
-        name: "_rank",
-        type: "uint256",
-      },
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
     ],
-    name: "getRankedStatement",
-    outputs: [
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
       {
-        components: [
+        "internalType": "uint256",
+        "name": "_rank",
+        "type": "uint256"
+      }
+    ],
+    "name": "getRankedStatement",
+    "outputs": [
+      {
+        "components": [
           {
-            internalType: "uint256",
-            name: "id",
-            type: "uint256",
+            "internalType": "uint256",
+            "name": "id",
+            "type": "uint256"
           },
           {
-            internalType: "string",
-            name: "text",
-            type: "string",
+            "internalType": "string",
+            "name": "text",
+            "type": "string"
           },
           {
-            internalType: "uint256",
-            name: "createdTimestamp",
-            type: "uint256",
+            "internalType": "uint256",
+            "name": "createdTimestamp",
+            "type": "uint256"
           },
           {
-            internalType: "int256",
-            name: "support",
-            type: "int256",
+            "internalType": "int256",
+            "name": "support",
+            "type": "int256"
           },
           {
-            internalType: "int256",
-            name: "rank",
-            type: "int256",
+            "internalType": "int256",
+            "name": "rank",
+            "type": "int256"
           },
           {
-            internalType: "int256",
-            name: "peakRank",
-            type: "int256",
-          },
+            "internalType": "int256",
+            "name": "peakRank",
+            "type": "int256"
+          }
         ],
-        internalType: "struct Forum.Statement",
-        name: "",
-        type: "tuple",
-      },
+        "internalType": "struct Forum.Statement",
+        "name": "",
+        "type": "tuple"
+      }
     ],
-    stateMutability: "view",
-    type: "function",
+    "stateMutability": "view",
+    "type": "function"
   },
   {
-    inputs: [
+    "inputs": [
       {
-        internalType: "uint256",
-        name: "_start",
-        type: "uint256",
+        "internalType": "uint256",
+        "name": "_start",
+        "type": "uint256"
       },
       {
-        internalType: "uint256",
-        name: "_limit",
-        type: "uint256",
-      },
+        "internalType": "uint256",
+        "name": "_limit",
+        "type": "uint256"
+      }
     ],
-    name: "getRankedStatementsPage",
-    outputs: [
+    "name": "getRankedStatementsPage",
+    "outputs": [
       {
-        components: [
+        "components": [
           {
-            internalType: "uint256",
-            name: "id",
-            type: "uint256",
+            "internalType": "uint256",
+            "name": "id",
+            "type": "uint256"
           },
           {
-            internalType: "string",
-            name: "text",
-            type: "string",
+            "internalType": "string",
+            "name": "text",
+            "type": "string"
           },
           {
-            internalType: "uint256",
-            name: "createdTimestamp",
-            type: "uint256",
+            "internalType": "uint256",
+            "name": "createdTimestamp",
+            "type": "uint256"
           },
           {
-            internalType: "int256",
-            name: "support",
-            type: "int256",
+            "internalType": "int256",
+            "name": "support",
+            "type": "int256"
           },
           {
-            internalType: "int256",
-            name: "rank",
-            type: "int256",
+            "internalType": "int256",
+            "name": "rank",
+            "type": "int256"
           },
           {
-            internalType: "int256",
-            name: "peakRank",
-            type: "int256",
-          },
+            "internalType": "int256",
+            "name": "peakRank",
+            "type": "int256"
+          }
         ],
-        internalType: "struct Forum.Statement[]",
-        name: "",
-        type: "tuple[]",
-      },
+        "internalType": "struct Forum.Statement[]",
+        "name": "",
+        "type": "tuple[]"
+      }
     ],
-    stateMutability: "view",
-    type: "function",
+    "stateMutability": "view",
+    "type": "function"
   },
   {
-    inputs: [
+    "inputs": [
       {
-        internalType: "uint256[]",
-        name: "_statementIds",
-        type: "uint256[]",
-      },
+        "internalType": "uint256[]",
+        "name": "_statementIds",
+        "type": "uint256[]"
+      }
     ],
-    name: "getStatementsById",
-    outputs: [
+    "name": "getStatementsById",
+    "outputs": [
       {
-        components: [
+        "components": [
           {
-            internalType: "uint256",
-            name: "id",
-            type: "uint256",
+            "internalType": "uint256",
+            "name": "id",
+            "type": "uint256"
           },
           {
-            internalType: "string",
-            name: "text",
-            type: "string",
+            "internalType": "string",
+            "name": "text",
+            "type": "string"
           },
           {
-            internalType: "uint256",
-            name: "createdTimestamp",
-            type: "uint256",
+            "internalType": "uint256",
+            "name": "createdTimestamp",
+            "type": "uint256"
           },
           {
-            internalType: "int256",
-            name: "support",
-            type: "int256",
+            "internalType": "int256",
+            "name": "support",
+            "type": "int256"
           },
           {
-            internalType: "int256",
-            name: "rank",
-            type: "int256",
+            "internalType": "int256",
+            "name": "rank",
+            "type": "int256"
           },
           {
-            internalType: "int256",
-            name: "peakRank",
-            type: "int256",
-          },
+            "internalType": "int256",
+            "name": "peakRank",
+            "type": "int256"
+          }
         ],
-        internalType: "struct Forum.Statement[]",
-        name: "",
-        type: "tuple[]",
-      },
+        "internalType": "struct Forum.Statement[]",
+        "name": "",
+        "type": "tuple[]"
+      }
     ],
-    stateMutability: "view",
-    type: "function",
+    "stateMutability": "view",
+    "type": "function"
   },
   {
-    inputs: [],
-    name: "getUserBalance",
-    outputs: [
+    "inputs": [],
+    "name": "getUserBalance",
+    "outputs": [
       {
-        internalType: "uint256",
-        name: "",
-        type: "uint256",
-      },
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
     ],
-    stateMutability: "view",
-    type: "function",
+    "stateMutability": "view",
+    "type": "function"
   },
   {
-    inputs: [],
-    name: "getUserStatementSupport",
-    outputs: [
+    "inputs": [],
+    "name": "getUserStatementSupport",
+    "outputs": [
       {
-        components: [
+        "components": [
           {
-            internalType: "uint256",
-            name: "statementId",
-            type: "uint256",
+            "internalType": "uint256",
+            "name": "statementId",
+            "type": "uint256"
           },
           {
-            internalType: "int256",
-            name: "support",
-            type: "int256",
-          },
+            "internalType": "int256",
+            "name": "support",
+            "type": "int256"
+          }
         ],
-        internalType: "struct Forum.StatementSupport[]",
-        name: "",
-        type: "tuple[]",
-      },
+        "internalType": "struct Forum.StatementSupport[]",
+        "name": "",
+        "type": "tuple[]"
+      }
     ],
-    stateMutability: "view",
-    type: "function",
+    "stateMutability": "view",
+    "type": "function"
   },
   {
-    inputs: [],
-    name: "isMember",
-    outputs: [
+    "inputs": [],
+    "name": "isMember",
+    "outputs": [
       {
-        internalType: "bool",
-        name: "",
-        type: "bool",
-      },
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
     ],
-    stateMutability: "view",
-    type: "function",
+    "stateMutability": "view",
+    "type": "function"
   },
   {
-    inputs: [],
-    name: "maxRankedStatements",
-    outputs: [
+    "inputs": [],
+    "name": "maxRankedStatements",
+    "outputs": [
       {
-        internalType: "uint256",
-        name: "",
-        type: "uint256",
-      },
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
     ],
-    stateMutability: "view",
-    type: "function",
+    "stateMutability": "view",
+    "type": "function"
   },
   {
-    inputs: [],
-    name: "nationality",
-    outputs: [
+    "inputs": [],
+    "name": "maxStatementLength",
+    "outputs": [
       {
-        internalType: "string",
-        name: "",
-        type: "string",
-      },
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
     ],
-    stateMutability: "view",
-    type: "function",
+    "stateMutability": "view",
+    "type": "function"
   },
   {
-    inputs: [],
-    name: "ourVoiceRegistry",
-    outputs: [
+    "inputs": [],
+    "name": "minStatementSupportToRank",
+    "outputs": [
       {
-        internalType: "contract AOurVoiceRegistry",
-        name: "",
-        type: "address",
-      },
+        "internalType": "int256",
+        "name": "",
+        "type": "int256"
+      }
     ],
-    stateMutability: "view",
-    type: "function",
+    "stateMutability": "view",
+    "type": "function"
   },
   {
-    inputs: [],
-    name: "rankedCount",
-    outputs: [
+    "inputs": [
       {
-        internalType: "uint256",
-        name: "",
-        type: "uint256",
-      },
+        "internalType": "bytes[]",
+        "name": "data",
+        "type": "bytes[]"
+      }
     ],
-    stateMutability: "view",
-    type: "function",
+    "name": "multicall",
+    "outputs": [
+      {
+        "internalType": "bytes[]",
+        "name": "results",
+        "type": "bytes[]"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
   },
   {
-    inputs: [],
-    name: "statementCount",
-    outputs: [
+    "inputs": [],
+    "name": "nationality",
+    "outputs": [
       {
-        internalType: "uint256",
-        name: "",
-        type: "uint256",
-      },
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
     ],
-    stateMutability: "view",
-    type: "function",
+    "stateMutability": "view",
+    "type": "function"
   },
   {
-    inputs: [
+    "inputs": [],
+    "name": "ourVoiceRegistry",
+    "outputs": [
       {
-        internalType: "uint256",
-        name: "",
-        type: "uint256",
-      },
+        "internalType": "contract AOurVoiceRegistry",
+        "name": "",
+        "type": "address"
+      }
     ],
-    name: "statementRankings",
-    outputs: [
-      {
-        internalType: "uint256",
-        name: "",
-        type: "uint256",
-      },
-    ],
-    stateMutability: "view",
-    type: "function",
+    "stateMutability": "view",
+    "type": "function"
   },
   {
-    inputs: [
+    "inputs": [],
+    "name": "rankedCount",
+    "outputs": [
       {
-        internalType: "uint256",
-        name: "",
-        type: "uint256",
-      },
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
     ],
-    name: "statements",
-    outputs: [
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
       {
-        internalType: "uint256",
-        name: "id",
-        type: "uint256",
+        "internalType": "uint256",
+        "name": "_expectedStep",
+        "type": "uint256"
+      }
+    ],
+    "name": "requireStep",
+    "outputs": [],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "statementCount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "statementRankings",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "statements",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
       },
       {
-        internalType: "string",
-        name: "text",
-        type: "string",
+        "internalType": "string",
+        "name": "text",
+        "type": "string"
       },
       {
-        internalType: "uint256",
-        name: "createdTimestamp",
-        type: "uint256",
+        "internalType": "uint256",
+        "name": "createdTimestamp",
+        "type": "uint256"
       },
       {
-        components: [
+        "components": [
           {
-            internalType: "int256",
-            name: "value",
-            type: "int256",
+            "internalType": "int256",
+            "name": "value",
+            "type": "int256"
           },
           {
-            internalType: "uint256",
-            name: "lastUpdated",
-            type: "uint256",
-          },
+            "internalType": "uint256",
+            "name": "lastUpdated",
+            "type": "uint256"
+          }
         ],
-        internalType: "struct Forum.Support",
-        name: "support",
-        type: "tuple",
+        "internalType": "struct Forum.Support",
+        "name": "support",
+        "type": "tuple"
       },
       {
-        internalType: "int256",
-        name: "rank",
-        type: "int256",
+        "internalType": "int256",
+        "name": "rank",
+        "type": "int256"
       },
+      {
+        "internalType": "int256",
+        "name": "peakRank",
+        "type": "int256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "lastEngagementEventTimestamp",
+        "type": "uint256"
+      }
     ],
-    stateMutability: "view",
-    type: "function",
+    "stateMutability": "view",
+    "type": "function"
   },
   {
-    inputs: [
+    "inputs": [],
+    "name": "stepDurationSeconds",
+    "outputs": [
       {
-        internalType: "bytes32",
-        name: "",
-        type: "bytes32",
-      },
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
     ],
-    name: "userCredits",
-    outputs: [
-      {
-        internalType: "uint256",
-        name: "credits",
-        type: "uint256",
-      },
-      {
-        internalType: "uint256",
-        name: "lastUpdated",
-        type: "uint256",
-      },
-    ],
-    stateMutability: "view",
-    type: "function",
+    "stateMutability": "view",
+    "type": "function"
   },
   {
-    inputs: [
+    "inputs": [],
+    "name": "userCreditAllowancePerStep",
+    "outputs": [
       {
-        internalType: "bytes32",
-        name: "",
-        type: "bytes32",
-      },
-      {
-        internalType: "uint256",
-        name: "",
-        type: "uint256",
-      },
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
     ],
-    name: "userSupportMap",
-    outputs: [
-      {
-        internalType: "int256",
-        name: "value",
-        type: "int256",
-      },
-      {
-        internalType: "uint256",
-        name: "lastUpdated",
-        type: "uint256",
-      },
-    ],
-    stateMutability: "view",
-    type: "function",
+    "stateMutability": "view",
+    "type": "function"
   },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "userCredits",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "credits",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "lastUpdated",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "userStartingCredits",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "userSupportMap",
+    "outputs": [
+      {
+        "internalType": "int256",
+        "name": "value",
+        "type": "int256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "lastUpdated",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
 ] as const;

--- a/frontend/src/hooks/useCreditAllocation.ts
+++ b/frontend/src/hooks/useCreditAllocation.ts
@@ -61,6 +61,13 @@ export const useCreditAllocation = (): CreditAllocation | null => {
       }
     }
 
+    // Include cost for staged new statements
+    for (const stmt of staged.stagedStatements) {
+      if (stmt.initialSupport !== 0) {
+        totalIncreaseCost += creditCost(stmt.initialSupport);
+      }
+    }
+
     const allocated = totalOnChainCost - totalDecreaseCost;
     const stagedAmount = totalDecreaseCost + totalIncreaseCost;
     const unallocated = onChain.credits - totalIncreaseCost;

--- a/frontend/src/hooks/useLocalStorageSet.ts
+++ b/frontend/src/hooks/useLocalStorageSet.ts
@@ -1,9 +1,18 @@
 import { useCallback, useEffect, useState } from "react";
+import { useAccount } from "wagmi";
 import { useForum } from "../state/Forum";
 
 /**
  * A hook that manages a Set<number> backed by localStorage.
- * The data is scoped per forum so each forum has its own set.
+ *
+ * The storage key is scoped by:
+ *   - forum name  — each forum has its own set
+ *   - chain fingerprint  — derived from the genesis block hash so data is
+ *     automatically invalidated whenever the chain is reset
+ *   - wallet address  — per-user data stays private to each account
+ *
+ * Returns empty data (no reads/writes) until the chain fingerprint has been
+ * resolved, preventing any stale-deployment data from leaking through.
  */
 const useLocalStorageSet = (
   key: string,
@@ -14,10 +23,21 @@ const useLocalStorageSet = (
   remove: (id: number) => void;
   toggle: (id: number) => void;
 } => {
-  const { name: forumName } = useForum();
-  const storageKey = `ourvoice:${key}:${forumName}`;
+  const { name: forumName, chainFingerprint } = useForum();
+  const { address } = useAccount();
+
+  // Shorten address to first 4 bytes (10 chars inc. "0x") for a compact key.
+  const addrKey = address ? address.slice(0, 10) : "anon";
+
+  // storageKey is undefined while the chain fingerprint is loading — hooks
+  // that depend on it will return empty data during that window.
+  const storageKey =
+    chainFingerprint !== undefined
+      ? `ourvoice:${key}:${forumName}:${chainFingerprint}:${addrKey}`
+      : undefined;
 
   const [set, setSet] = useState<Set<number>>(() => {
+    if (!storageKey) return new Set();
     try {
       const stored = localStorage.getItem(storageKey);
       if (stored) {
@@ -29,8 +49,12 @@ const useLocalStorageSet = (
     return new Set();
   });
 
-  // Re-read from localStorage when the forum changes
+  // Re-read from localStorage when the key changes (forum, fingerprint, or address)
   useEffect(() => {
+    if (!storageKey) {
+      setSet(new Set());
+      return;
+    }
     try {
       const stored = localStorage.getItem(storageKey);
       if (stored) {
@@ -45,6 +69,7 @@ const useLocalStorageSet = (
 
   // Persist to localStorage whenever the set changes
   useEffect(() => {
+    if (!storageKey) return;
     try {
       localStorage.setItem(storageKey, JSON.stringify([...set]));
     } catch {

--- a/frontend/src/state/Forum.tsx
+++ b/frontend/src/state/Forum.tsx
@@ -5,11 +5,40 @@ import React, {
   useContext,
   useEffect,
   useMemo,
+  useState,
 } from "react";
+import { usePublicClient } from "wagmi";
 import { FORUMS } from "../contracts";
 export { FORUM_ABI } from "../contracts";
 
 const FORUM_STORAGE_KEY = "ourvoice:selectedForum";
+
+/**
+ * Keys that must survive a chain-fingerprint sweep because they are either
+ * chain-agnostic (selected forum) or already scoped by address (nickname).
+ */
+const SWEEP_EXEMPT_PREFIXES = [
+  "ourvoice:selectedForum",
+  "ourvoice:nickname:",
+];
+
+/**
+ * Remove all `ourvoice:*` localStorage keys that do not belong to the
+ * current chain deployment (identified by `fingerprint`).
+ */
+const sweepStaleKeys = (fingerprint: string) => {
+  try {
+    const keys = Object.keys(localStorage).filter(
+      (k) =>
+        k.startsWith("ourvoice:") &&
+        !SWEEP_EXEMPT_PREFIXES.some((p) => k.startsWith(p)) &&
+        !k.includes(fingerprint),
+    );
+    keys.forEach((k) => localStorage.removeItem(k));
+  } catch {
+    // Silently fail if localStorage is unavailable
+  }
+};
 
 type ForumName = keyof typeof FORUMS;
 
@@ -34,6 +63,12 @@ type ForumContextValue = {
   forumContractAddress: `0x${string}`;
   name: string;
   setForum: (name: ForumName) => void;
+  /**
+   * A short hex string derived from the genesis block hash that uniquely
+   * identifies this chain deployment. `undefined` until the genesis block
+   * has been fetched. localStorage reads/writes should be gated on this.
+   */
+  chainFingerprint: string | undefined;
 };
 
 export const ForumContext = createContext<ForumContextValue | undefined>(
@@ -47,6 +82,34 @@ export const ForumProvider: FC<{ children: React.ReactNode }> = ({
     return getStoredForum() ?? "global";
   });
   const address = useMemo(() => FORUMS[forumName], [forumName]);
+  const publicClient = usePublicClient();
+
+  // Fingerprint derived from the genesis block hash — unique per chain
+  // instance. Changes whenever the chain is reset (docker compose down -v).
+  const [chainFingerprint, setChainFingerprint] = useState<string | undefined>(
+    undefined,
+  );
+
+  useEffect(() => {
+    if (!publicClient) return;
+    let cancelled = false;
+    publicClient
+      .getBlock({ blockNumber: 0n })
+      .then((block) => {
+        if (cancelled) return;
+        // Use 12 hex chars (6 bytes) — short enough for a key suffix,
+        // collision-resistant enough for a local cache-bust fingerprint.
+        const fp = (block.hash ?? "unknown").slice(2, 14);
+        sweepStaleKeys(fp);
+        setChainFingerprint(fp);
+      })
+      .catch(() => {
+        if (!cancelled) setChainFingerprint("unknown");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [publicClient]);
 
   useEffect(() => {
     try {
@@ -70,6 +133,7 @@ export const ForumProvider: FC<{ children: React.ReactNode }> = ({
         forumContractAddress: address,
         name: forumName,
         setForum,
+        chainFingerprint,
       }}
     >
       {children}

--- a/frontend/src/state/Forum.tsx
+++ b/frontend/src/state/Forum.tsx
@@ -17,10 +17,7 @@ const FORUM_STORAGE_KEY = "ourvoice:selectedForum";
  * Keys that must survive a chain-fingerprint sweep because they are either
  * chain-agnostic (selected forum) or already scoped by address (nickname).
  */
-const SWEEP_EXEMPT_PREFIXES = [
-  "ourvoice:selectedForum",
-  "ourvoice:nickname:",
-];
+const SWEEP_EXEMPT_PREFIXES = ["ourvoice:selectedForum", "ourvoice:nickname:"];
 
 /**
  * Remove all `ourvoice:*` localStorage keys that do not belong to the

--- a/frontend/src/state/UserVotes.tsx
+++ b/frontend/src/state/UserVotes.tsx
@@ -336,9 +336,9 @@ const reducer = (
     ...newState,
     staged: newState.staged
       ? {
-        ...newState.staged,
-        credits: stagedCredits,
-      }
+          ...newState.staged,
+          credits: stagedCredits,
+        }
       : undefined,
     hasStagedChanges,
     hasEnoughCredits: stagedCredits >= 0,
@@ -402,10 +402,7 @@ export const UserVoteProvider: FC<{
   });
 
   // Read the current decay step from the chain, refreshed on every block.
-  const {
-    data: onChainStep,
-    refetch: refetchStep,
-  } = useReadContract({
+  const { data: onChainStep, refetch: refetchStep } = useReadContract({
     address: forumContractAddress,
     abi: FORUM_ABI,
     functionName: "getCurrentStep",
@@ -428,33 +425,30 @@ export const UserVoteProvider: FC<{
     },
   });
 
-  const {
-    data: onChainUserStatementSupport,
-    refetch: refetchSupport,
-  } = useReadContract({
-    address: forumContractAddress,
-    abi: FORUM_ABI,
-    account: address,
-    functionName: "getUserStatementSupport",
-    args: [],
-    query: {
-      enabled: Boolean(address && isUserVerified),
-    },
-  });
+  const { data: onChainUserStatementSupport, refetch: refetchSupport } =
+    useReadContract({
+      address: forumContractAddress,
+      abi: FORUM_ABI,
+      account: address,
+      functionName: "getUserStatementSupport",
+      args: [],
+      query: {
+        enabled: Boolean(address && isUserVerified),
+      },
+    });
 
-  const {
-    data: onChainUserBalance,
-    refetch: refetchBalance,
-  } = useReadContract({
-    address: forumContractAddress,
-    abi: FORUM_ABI,
-    account: address,
-    functionName: "getUserBalance",
-    args: [],
-    query: {
-      enabled: Boolean(address && isUserVerified),
+  const { data: onChainUserBalance, refetch: refetchBalance } = useReadContract(
+    {
+      address: forumContractAddress,
+      abi: FORUM_ABI,
+      account: address,
+      functionName: "getUserBalance",
+      args: [],
+      query: {
+        enabled: Boolean(address && isUserVerified),
+      },
     },
-  });
+  );
 
   const refetch = useCallback(() => {
     void refetchSupport();
@@ -561,7 +555,11 @@ export const UserVoteProvider: FC<{
         //    the user last saw the UI state. Uses the same last-block value that
         //    drives all on-chain reads, so any mismatch surfaces as a StaleStep
         //    that the user can resolve by retrying.
-        if (stepDurationSeconds && stepDurationSeconds > 0n && onChainStep !== undefined) {
+        if (
+          stepDurationSeconds &&
+          stepDurationSeconds > 0n &&
+          onChainStep !== undefined
+        ) {
           calls.push(
             encodeFunctionData({
               abi: FORUM_ABI,
@@ -614,10 +612,7 @@ export const UserVoteProvider: FC<{
 
         dispatch({ type: "COMMIT_SUBMITTED", payload: { txHash } });
       } catch (err: unknown) {
-
-
         if (err instanceof BaseError) {
-
           if (err.shortMessage?.toLowerCase().includes("rejected")) {
             dispatch({ type: "COMMIT_CANCELLED" });
             return;
@@ -631,7 +626,6 @@ export const UserVoteProvider: FC<{
             dispatch({ type: "COMMIT_STALE_STEP" });
             return;
           }
-
         }
 
         const errStr = JSON.stringify(err, Object.getOwnPropertyNames(err));

--- a/frontend/src/state/UserVotes.tsx
+++ b/frontend/src/state/UserVotes.tsx
@@ -13,7 +13,12 @@ import {
   useWaitForTransactionReceipt,
   useWriteContract,
 } from "wagmi";
-import { encodeFunctionData, parseEventLogs } from "viem";
+import {
+  encodeFunctionData,
+  parseEventLogs,
+  BaseError,
+  ContractFunctionRevertedError,
+} from "viem";
 import { FORUM_ABI, useForum } from "./Forum";
 import useBlockSync from "@/hooks/useBlockSync";
 import useLocalStorageSet from "@/hooks/useLocalStorageSet";
@@ -110,6 +115,11 @@ type UnstageStatement = {
   payload: { tempId: string };
 };
 
+type UpdateStagedInitialSupport = {
+  type: "UPDATE_STAGED_INITIAL_SUPPORT";
+  payload: { tempId: string; newSupport: number };
+};
+
 type CommitStaleStep = {
   type: "COMMIT_STALE_STEP";
 };
@@ -126,6 +136,7 @@ type UserSupportAction =
   | ResetCommitStatus
   | StageStatement
   | UnstageStatement
+  | UpdateStagedInitialSupport
   | CommitStaleStep;
 
 // Triangle number: triangle(x) = x*(x+1)/2
@@ -278,6 +289,19 @@ const reducer = (
       };
       break;
     }
+    case "UPDATE_STAGED_INITIAL_SUPPORT": {
+      if (!state.staged) break;
+      newState.staged = {
+        ...state.staged,
+        supportAdjustments: new Map(state.staged.supportAdjustments),
+        stagedStatements: state.staged.stagedStatements.map((s) =>
+          s.tempId === action.payload.tempId
+            ? { ...s, initialSupport: action.payload.newSupport }
+            : s,
+        ),
+      };
+      break;
+    }
     case "COMMIT_STALE_STEP": {
       newState.commitStatus = "stale-step";
       newState.pendingTxHash = undefined;
@@ -312,15 +336,14 @@ const reducer = (
     ...newState,
     staged: newState.staged
       ? {
-          ...newState.staged,
-          credits: stagedCredits,
-        }
+        ...newState.staged,
+        credits: stagedCredits,
+      }
       : undefined,
     hasStagedChanges,
     hasEnoughCredits: stagedCredits >= 0,
   };
 
-  console.log("Updating state: ", newState);
   return newState;
 };
 
@@ -335,6 +358,7 @@ type UserNotVerifiedContextValue = {
   hasAdjustment: undefined;
   stageStatement: undefined;
   unstageStatement: undefined;
+  updateStagedInitialSupport: undefined;
 };
 
 type UserSupportContextValue = {
@@ -348,6 +372,7 @@ type UserSupportContextValue = {
   hasAdjustment: (statementId: number) => boolean;
   stageStatement: (text: string, initialSupport?: number) => void;
   unstageStatement: (tempId: string) => void;
+  updateStagedInitialSupport: (tempId: string, newSupport: number) => void;
 };
 
 export const UserVoteContext = createContext<
@@ -367,14 +392,24 @@ export const UserVoteProvider: FC<{
   const { writeContractAsync } = useWriteContract();
   const { address } = useAccount();
   const { forumContractAddress } = useForum();
-  console.log("UserVoteProvider for address: ", address);
-  console.log("Forum contract address: ", forumContractAddress);
 
   // Read stepDurationSeconds for requireStep guard
   const { data: stepDurationSeconds } = useReadContract({
     address: forumContractAddress,
     abi: FORUM_ABI,
     functionName: "stepDurationSeconds",
+    query: { enabled: !!forumContractAddress },
+  });
+
+  // Read the current decay step from the chain, refreshed on every block.
+  const {
+    data: onChainStep,
+    refetch: refetchStep,
+  } = useReadContract({
+    address: forumContractAddress,
+    abi: FORUM_ABI,
+    functionName: "getCurrentStep",
+    args: [],
     query: { enabled: !!forumContractAddress },
   });
 
@@ -393,12 +428,9 @@ export const UserVoteProvider: FC<{
     },
   });
 
-  console.log("User verified status: ", isUserVerified);
-
   const {
     data: onChainUserStatementSupport,
     refetch: refetchSupport,
-    error: supportError,
   } = useReadContract({
     address: forumContractAddress,
     abi: FORUM_ABI,
@@ -413,7 +445,6 @@ export const UserVoteProvider: FC<{
   const {
     data: onChainUserBalance,
     refetch: refetchBalance,
-    error: balanceError,
   } = useReadContract({
     address: forumContractAddress,
     abi: FORUM_ABI,
@@ -428,15 +459,8 @@ export const UserVoteProvider: FC<{
   const refetch = useCallback(() => {
     void refetchSupport();
     void refetchBalance();
-  }, [refetchSupport, refetchBalance]);
-
-  console.log("Support error: ", supportError);
-  console.log("Balance error: ", balanceError);
-  console.log(
-    "Fetched user support from contract: ",
-    onChainUserStatementSupport,
-  );
-  console.log("Fetched user balance from contract: ", onChainUserBalance);
+    void refetchStep();
+  }, [refetchSupport, refetchBalance, refetchStep]);
 
   useEffect(() => {
     // Load state from blockchain
@@ -444,7 +468,6 @@ export const UserVoteProvider: FC<{
       onChainUserStatementSupport !== undefined &&
       onChainUserBalance !== undefined
     ) {
-      console.log("Dispatching SYNC_ONCHAIN_STATE");
       dispatch({
         type: "SYNC_ONCHAIN_STATE",
         payload: {
@@ -525,12 +548,6 @@ export const UserVoteProvider: FC<{
 
   const commitChanges = useCallback(async () => {
     if (state.hasStagedChanges && state.hasEnoughCredits && state.staged) {
-      console.log(
-        "Committing changes: ",
-        state.staged.supportAdjustments,
-        state.staged.stagedStatements,
-      );
-
       const hasSupportAdjustments = state.staged.supportAdjustments.size > 0;
 
       dispatch({ type: "BEGIN_COMMIT" });
@@ -539,15 +556,16 @@ export const UserVoteProvider: FC<{
         // Build the list of encoded calls for multicall
         const calls: `0x${string}`[] = [];
 
-        // 1. requireStep guard — protects against decay drift
-        if (stepDurationSeconds && stepDurationSeconds > 0n) {
-          const currentStep =
-            BigInt(Math.floor(Date.now() / 1000)) / stepDurationSeconds;
+        // 1. requireStep guard — ensures the decay step hasn't changed since
+        //    the user last saw the UI state. Uses the same last-block value that
+        //    drives all on-chain reads, so any mismatch surfaces as a StaleStep
+        //    that the user can resolve by retrying.
+        if (stepDurationSeconds && stepDurationSeconds > 0n && onChainStep !== undefined) {
           calls.push(
             encodeFunctionData({
               abi: FORUM_ABI,
               functionName: "requireStep",
-              args: [currentStep],
+              args: [onChainStep],
             }),
           );
         }
@@ -595,20 +613,40 @@ export const UserVoteProvider: FC<{
 
         dispatch({ type: "COMMIT_SUBMITTED", payload: { txHash } });
       } catch (err: unknown) {
-        // Check for StaleStep revert
-        const errorStr = String(err);
-        if (errorStr.includes("StaleStep")) {
-          dispatch({ type: "COMMIT_STALE_STEP" });
-        } else {
-          // User rejected the transaction in their wallet, or other error
-          dispatch({ type: "COMMIT_CANCELLED" });
+
+
+        if (err instanceof BaseError) {
+
+          if (err.shortMessage?.toLowerCase().includes("rejected")) {
+            dispatch({ type: "COMMIT_CANCELLED" });
+            return;
+          }
+
+          const revert = err.walk(
+            (e) => e instanceof ContractFunctionRevertedError,
+          ) as ContractFunctionRevertedError | null;
+
+          if (revert && revert.data?.errorName === "StaleStep") {
+            dispatch({ type: "COMMIT_STALE_STEP" });
+            return;
+          }
+
         }
+
+        const errStr = JSON.stringify(err, Object.getOwnPropertyNames(err));
+        if (errStr.includes("0x595d8517") || errStr.includes("StaleStep")) {
+          dispatch({ type: "COMMIT_STALE_STEP" });
+          return;
+        }
+
+        dispatch({ type: "COMMIT_ERROR" });
       }
     }
   }, [
     state,
     writeContractAsync,
     forumContractAddress,
+    onChainStep,
     dispatch,
     stepDurationSeconds,
   ]);
@@ -664,6 +702,17 @@ export const UserVoteProvider: FC<{
     [dispatch],
   );
 
+  // Update the initial support value of a staged statement
+  const updateStagedInitialSupport = useCallback(
+    (tempId: string, newSupport: number) => {
+      dispatch({
+        type: "UPDATE_STAGED_INITIAL_SUPPORT",
+        payload: { tempId, newSupport },
+      });
+    },
+    [dispatch],
+  );
+
   if (isUserVerified) {
     return (
       <UserVoteContext.Provider
@@ -678,6 +727,7 @@ export const UserVoteProvider: FC<{
           hasAdjustment,
           stageStatement,
           unstageStatement,
+          updateStagedInitialSupport,
         }}
       >
         {children}
@@ -697,6 +747,7 @@ export const UserVoteProvider: FC<{
           hasAdjustment: undefined,
           stageStatement: undefined,
           unstageStatement: undefined,
+          updateStagedInitialSupport: undefined,
         }}
       >
         {children}

--- a/frontend/src/state/UserVotes.tsx
+++ b/frontend/src/state/UserVotes.tsx
@@ -527,7 +527,8 @@ export const UserVoteProvider: FC<{
       state.commitStatus !== "idle" &&
       state.commitStatus !== "confirmed" &&
       state.commitStatus !== "cancelled" &&
-      state.commitStatus !== "error"
+      state.commitStatus !== "error" &&
+      state.commitStatus !== "stale-step"
     ) {
       commitTimeoutRef.current = setTimeout(() => {
         dispatch({ type: "COMMIT_ERROR" });

--- a/frontend/src/state/UserVotes.tsx
+++ b/frontend/src/state/UserVotes.tsx
@@ -13,8 +13,10 @@ import {
   useWaitForTransactionReceipt,
   useWriteContract,
 } from "wagmi";
+import { encodeFunctionData, parseEventLogs } from "viem";
 import { FORUM_ABI, useForum } from "./Forum";
 import useBlockSync from "@/hooks/useBlockSync";
+import useLocalStorageSet from "@/hooks/useLocalStorageSet";
 
 interface StatementSupport {
   statementId: bigint;
@@ -29,6 +31,14 @@ interface UserSupport {
 interface StagedSupport {
   credits: number;
   supportAdjustments: Map<number, number>;
+  stagedStatements: StagedStatement[];
+}
+
+export interface StagedStatement {
+  /** Client-side temporary ID (uuid or counter) — NOT an on-chain ID. */
+  tempId: string;
+  text: string;
+  initialSupport: number;
 }
 
 export type CommitStatus =
@@ -37,6 +47,7 @@ export type CommitStatus =
   | "pending-confirmation"
   | "confirmed"
   | "cancelled"
+  | "stale-step"
   | "error";
 
 interface UserSupportState {
@@ -89,6 +100,20 @@ type ResetCommitStatus = {
   type: "RESET_COMMIT_STATUS";
 };
 
+type StageStatement = {
+  type: "STAGE_STATEMENT";
+  payload: { tempId: string; text: string; initialSupport: number };
+};
+
+type UnstageStatement = {
+  type: "UNSTAGE_STATEMENT";
+  payload: { tempId: string };
+};
+
+type CommitStaleStep = {
+  type: "COMMIT_STALE_STEP";
+};
+
 type UserSupportAction =
   | SyncOnChainState
   | StageUserSupport
@@ -98,7 +123,10 @@ type UserSupportAction =
   | CommitConfirmed
   | CommitCancelled
   | CommitError
-  | ResetCommitStatus;
+  | ResetCommitStatus
+  | StageStatement
+  | UnstageStatement
+  | CommitStaleStep;
 
 // Triangle number: triangle(x) = x*(x+1)/2
 const triangle = (x: number): number => (x * (x + 1)) / 2;
@@ -139,6 +167,7 @@ const reducer = (
         newState.staged = {
           credits: onChainState.credits,
           supportAdjustments: new Map(),
+          stagedStatements: [],
         };
         newState.commitStatus = "confirmed";
         newState.pendingTxHash = undefined;
@@ -147,6 +176,7 @@ const reducer = (
         newState.staged = {
           credits: onChainState.credits,
           supportAdjustments: new Map(),
+          stagedStatements: [],
         };
       }
       break;
@@ -161,6 +191,7 @@ const reducer = (
       newState.staged = {
         ...state.staged,
         supportAdjustments: new Map(state.staged.supportAdjustments),
+        stagedStatements: [...state.staged.stagedStatements],
       };
       if (adjustment === 0) {
         newState.staged.supportAdjustments.delete(Number(statementId));
@@ -173,6 +204,7 @@ const reducer = (
       newState.staged = {
         credits: newState.onChain ? newState.onChain.credits : 0,
         supportAdjustments: new Map(),
+        stagedStatements: [],
       };
       break;
     }
@@ -205,11 +237,49 @@ const reducer = (
       newState.staged = {
         credits: newState.onChain ? newState.onChain.credits : 0,
         supportAdjustments: new Map(),
+        stagedStatements: [],
       };
       break;
     }
     case "RESET_COMMIT_STATUS": {
       newState.commitStatus = "idle";
+      newState.pendingTxHash = undefined;
+      newState.confirmedBlockNumber = undefined;
+      break;
+    }
+    case "STAGE_STATEMENT": {
+      if (!state.staged) {
+        throw new Error(
+          "Cannot stage statement before on-chain state is synced",
+        );
+      }
+      newState.staged = {
+        ...state.staged,
+        supportAdjustments: new Map(state.staged.supportAdjustments),
+        stagedStatements: [
+          ...state.staged.stagedStatements,
+          {
+            tempId: action.payload.tempId,
+            text: action.payload.text,
+            initialSupport: action.payload.initialSupport,
+          },
+        ],
+      };
+      break;
+    }
+    case "UNSTAGE_STATEMENT": {
+      if (!state.staged) break;
+      newState.staged = {
+        ...state.staged,
+        supportAdjustments: new Map(state.staged.supportAdjustments),
+        stagedStatements: state.staged.stagedStatements.filter(
+          (s) => s.tempId !== action.payload.tempId,
+        ),
+      };
+      break;
+    }
+    case "COMMIT_STALE_STEP": {
+      newState.commitStatus = "stale-step";
       newState.pendingTxHash = undefined;
       newState.confirmedBlockNumber = undefined;
       break;
@@ -226,9 +296,17 @@ const reducer = (
       const newSupport = onChainSupport + adjustment;
       totalAdjustmentCost += adjustmentCost(onChainSupport, newSupport);
     }
+    // Include cost for staged new statements
+    for (const stmt of newState.staged.stagedStatements) {
+      totalAdjustmentCost += adjustmentCost(0, stmt.initialSupport);
+    }
   }
 
   const stagedCredits = (newState.onChain?.credits || 0) - totalAdjustmentCost;
+
+  const hasStagedChanges =
+    (newState.staged?.supportAdjustments.size ?? 0) > 0 ||
+    (newState.staged?.stagedStatements.length ?? 0) > 0;
 
   newState = {
     ...newState,
@@ -238,9 +316,7 @@ const reducer = (
           credits: stagedCredits,
         }
       : undefined,
-    hasStagedChanges: newState.staged?.supportAdjustments.size
-      ? newState.staged.supportAdjustments.size > 0
-      : false,
+    hasStagedChanges,
     hasEnoughCredits: stagedCredits >= 0,
   };
 
@@ -252,31 +328,35 @@ type UserNotVerifiedContextValue = {
   isUserVerified: false;
   state: undefined;
   dispatch: undefined;
-  commitSupport: undefined;
+  commitChanges: undefined;
   resetCommitStatus: undefined;
   getEffectiveSupport: undefined;
   getOnChainSupport: undefined;
   hasAdjustment: undefined;
+  stageStatement: undefined;
+  unstageStatement: undefined;
 };
 
 type UserSupportContextValue = {
   isUserVerified: true;
   state: UserSupportState;
   dispatch: React.Dispatch<UserSupportAction>;
-  commitSupport: () => void | Promise<void>;
+  commitChanges: () => void | Promise<void>;
   resetCommitStatus: () => void;
   getEffectiveSupport: (statementId: number) => number;
   getOnChainSupport: (statementId: number) => number;
   hasAdjustment: (statementId: number) => boolean;
+  stageStatement: (text: string, initialSupport?: number) => void;
+  unstageStatement: (tempId: string) => void;
 };
 
 export const UserVoteContext = createContext<
   UserNotVerifiedContextValue | UserSupportContextValue | undefined
 >(undefined);
 
-export const UserVoteProvider: FC<{ children: React.ReactNode }> = ({
-  children,
-}) => {
+export const UserVoteProvider: FC<{
+  children: React.ReactNode;
+}> = ({ children }) => {
   const [state, dispatch] = useReducer(reducer, {
     onChain: undefined,
     staged: undefined,
@@ -289,6 +369,18 @@ export const UserVoteProvider: FC<{ children: React.ReactNode }> = ({
   const { forumContractAddress } = useForum();
   console.log("UserVoteProvider for address: ", address);
   console.log("Forum contract address: ", forumContractAddress);
+
+  // Read stepDurationSeconds for requireStep guard
+  const { data: stepDurationSeconds } = useReadContract({
+    address: forumContractAddress,
+    abi: FORUM_ABI,
+    functionName: "stepDurationSeconds",
+    query: { enabled: !!forumContractAddress },
+  });
+
+  // Track authored statements in localStorage for "My Statements"
+  const { add: addAuthoredStatement } =
+    useLocalStorageSet("authoredStatements");
 
   const { data: isUserVerified } = useReadContract({
     address: forumContractAddress,
@@ -375,19 +467,35 @@ export const UserVoteProvider: FC<{ children: React.ReactNode }> = ({
     },
   });
 
-  // When receipt arrives, dispatch COMMIT_CONFIRMED with the block number
+  // When receipt arrives, extract authored statement IDs from logs and
+  // dispatch COMMIT_CONFIRMED with the block number.
   useEffect(() => {
     if (
       txReceipt &&
       state.commitStatus === "pending-confirmation" &&
       state.confirmedBlockNumber === undefined
     ) {
+      // Decode StatementAdded events to get the actual on-chain IDs
+      const statementEvents = parseEventLogs({
+        abi: FORUM_ABI,
+        logs: txReceipt.logs,
+        eventName: "StatementAdded",
+      });
+      for (const event of statementEvents) {
+        addAuthoredStatement(Number(event.args.id));
+      }
+
       dispatch({
         type: "COMMIT_CONFIRMED",
         payload: { blockNumber: txReceipt.blockNumber },
       });
     }
-  }, [txReceipt, state.commitStatus, state.confirmedBlockNumber]);
+  }, [
+    txReceipt,
+    state.commitStatus,
+    state.confirmedBlockNumber,
+    addAuthoredStatement,
+  ]);
 
   // Timeout: if commit is in-flight for more than 30 seconds, treat as error
   const commitTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -415,38 +523,95 @@ export const UserVoteProvider: FC<{ children: React.ReactNode }> = ({
     };
   }, [state.commitStatus]);
 
-  const commitSupport = useCallback(async () => {
+  const commitChanges = useCallback(async () => {
     if (state.hasStagedChanges && state.hasEnoughCredits && state.staged) {
       console.log(
-        "Committing support changes: ",
+        "Committing changes: ",
         state.staged.supportAdjustments,
+        state.staged.stagedStatements,
       );
 
-      const supportAdjustments: { statementId: bigint; value: bigint }[] = [];
-      for (const [statementId, adjustment] of state.staged.supportAdjustments) {
-        supportAdjustments.push({
-          statementId: BigInt(statementId),
-          value: BigInt(adjustment),
-        });
-      }
+      const hasSupportAdjustments = state.staged.supportAdjustments.size > 0;
 
       dispatch({ type: "BEGIN_COMMIT" });
 
       try {
+        // Build the list of encoded calls for multicall
+        const calls: `0x${string}`[] = [];
+
+        // 1. requireStep guard — protects against decay drift
+        if (stepDurationSeconds && stepDurationSeconds > 0n) {
+          const currentStep =
+            BigInt(Math.floor(Date.now() / 1000)) / stepDurationSeconds;
+          calls.push(
+            encodeFunctionData({
+              abi: FORUM_ABI,
+              functionName: "requireStep",
+              args: [currentStep],
+            }),
+          );
+        }
+
+        // 2. addStatement calls for staged new statements
+        for (const stmt of state.staged.stagedStatements) {
+          calls.push(
+            encodeFunctionData({
+              abi: FORUM_ABI,
+              functionName: "addStatement",
+              args: [stmt.text, BigInt(stmt.initialSupport)],
+            }),
+          );
+        }
+
+        // 3. adjustSupport call for support adjustments on existing statements
+        if (hasSupportAdjustments) {
+          const supportAdjustments: { statementId: bigint; value: bigint }[] =
+            [];
+          for (const [statementId, adjustment] of state.staged
+            .supportAdjustments) {
+            supportAdjustments.push({
+              statementId: BigInt(statementId),
+              value: BigInt(adjustment),
+            });
+          }
+          calls.push(
+            encodeFunctionData({
+              abi: FORUM_ABI,
+              functionName: "adjustSupport",
+              args: [supportAdjustments],
+            }),
+          );
+        }
+
+        // Use multicall to batch everything in a single transaction.
+        // Authored statement IDs are extracted from the receipt logs in
+        // the COMMIT_CONFIRMED effect, avoiding prediction race conditions.
         const txHash = await writeContractAsync({
           address: forumContractAddress,
           abi: FORUM_ABI,
-          functionName: "adjustSupport",
-          args: [supportAdjustments],
+          functionName: "multicall",
+          args: [calls],
         });
 
         dispatch({ type: "COMMIT_SUBMITTED", payload: { txHash } });
-      } catch {
-        // User rejected the transaction in their wallet, or other error
-        dispatch({ type: "COMMIT_CANCELLED" });
+      } catch (err: unknown) {
+        // Check for StaleStep revert
+        const errorStr = String(err);
+        if (errorStr.includes("StaleStep")) {
+          dispatch({ type: "COMMIT_STALE_STEP" });
+        } else {
+          // User rejected the transaction in their wallet, or other error
+          dispatch({ type: "COMMIT_CANCELLED" });
+        }
       }
     }
-  }, [state, writeContractAsync, forumContractAddress, dispatch]);
+  }, [
+    state,
+    writeContractAsync,
+    forumContractAddress,
+    dispatch,
+    stepDurationSeconds,
+  ]);
 
   const resetCommitStatus = useCallback(() => {
     dispatch({ type: "RESET_COMMIT_STATUS" });
@@ -479,6 +644,26 @@ export const UserVoteProvider: FC<{ children: React.ReactNode }> = ({
     [state.staged],
   );
 
+  // Stage a new statement for batched submission
+  const stageStatement = useCallback(
+    (text: string, initialSupport = 0) => {
+      const tempId = crypto.randomUUID();
+      dispatch({
+        type: "STAGE_STATEMENT",
+        payload: { tempId, text, initialSupport },
+      });
+    },
+    [dispatch],
+  );
+
+  // Remove a staged statement before it is committed
+  const unstageStatement = useCallback(
+    (tempId: string) => {
+      dispatch({ type: "UNSTAGE_STATEMENT", payload: { tempId } });
+    },
+    [dispatch],
+  );
+
   if (isUserVerified) {
     return (
       <UserVoteContext.Provider
@@ -486,11 +671,13 @@ export const UserVoteProvider: FC<{ children: React.ReactNode }> = ({
           isUserVerified: isUserVerified,
           state,
           dispatch,
-          commitSupport,
+          commitChanges,
           resetCommitStatus,
           getEffectiveSupport,
           getOnChainSupport,
           hasAdjustment,
+          stageStatement,
+          unstageStatement,
         }}
       >
         {children}
@@ -503,11 +690,13 @@ export const UserVoteProvider: FC<{ children: React.ReactNode }> = ({
           isUserVerified: !!isUserVerified,
           state: undefined,
           dispatch: undefined,
-          commitSupport: undefined,
+          commitChanges: undefined,
           resetCommitStatus: undefined,
           getEffectiveSupport: undefined,
           getOnChainSupport: undefined,
           hasAdjustment: undefined,
+          stageStatement: undefined,
+          unstageStatement: undefined,
         }}
       >
         {children}


### PR DESCRIPTION
This pull request introduces several enhancements and refactorings to the `Forum` smart contract and its associated tests. The main improvements include support for multicall operations, the ability to specify initial support and charge credits when adding statements, and new mechanisms for step-based decay validation. The test suite has been updated to reflect these changes.

**Smart contract feature upgrades:**

* Added OpenZeppelin's `Multicall` support to the `Forum` contract, enabling atomic execution of multiple calls in a single transaction. (`blockchain/contracts/Forum.sol`)
* Introduced `getCurrentStep` and `requireStep` methods to support step-based decay validation and guard against frontend clock drift. (`blockchain/contracts/Forum.sol`)
* Added a new custom error `StaleStep` for step validation failures. (`blockchain/contracts/Forum.sol`)

**Statement creation and ranking logic:**

* Refactored `addStatement` to accept an `_initialSupport` parameter, apply initial support, and charge user credits if specified. Returns the statement ID. (`blockchain/contracts/Forum.sol`)
* Updated ranking logic to automatically unrank statements if their support falls below the minimum threshold. (`blockchain/contracts/Forum.sol`)

**Test suite updates:**

* Updated all test cases to use the new `addStatement` signature with the `_initialSupport` argument. (`blockchain/contracts/Forum.t.sol`) [[1]](diffhunk://#diff-af9e60e89760bf1f7cd7c3c9f5db397041e21c95b30d332b216c030fd7152421L181-R181) [[2]](diffhunk://#diff-af9e60e89760bf1f7cd7c3c9f5db397041e21c95b30d332b216c030fd7152421L199-R199) [[3]](diffhunk://#diff-af9e60e89760bf1f7cd7c3c9f5db397041e21c95b30d332b216c030fd7152421L211-R211) [[4]](diffhunk://#diff-af9e60e89760bf1f7cd7c3c9f5db397041e21c95b30d332b216c030fd7152421L224-R224) [[5]](diffhunk://#diff-af9e60e89760bf1f7cd7c3c9f5db397041e21c95b30d332b216c030fd7152421L238-R239) [[6]](diffhunk://#diff-af9e60e89760bf1f7cd7c3c9f5db397041e21c95b30d332b216c030fd7152421L273-R274) [[7]](diffhunk://#diff-af9e60e89760bf1f7cd7c3c9f5db397041e21c95b30d332b216c030fd7152421L296-R298) [[8]](diffhunk://#diff-af9e60e89760bf1f7cd7c3c9f5db397041e21c95b30d332b216c030fd7152421L328-R328) [[9]](diffhunk://#diff-af9e60e89760bf1f7cd7c3c9f5db397041e21c95b30d332b216c030fd7152421L347-R348) [[10]](diffhunk://#diff-af9e60e89760bf1f7cd7c3c9f5db397041e21c95b30d332b216c030fd7152421L380-R380) [[11]](diffhunk://#diff-af9e60e89760bf1f7cd7c3c9f5db397041e21c95b30d332b216c030fd7152421L397-R397) [[12]](diffhunk://#diff-af9e60e89760bf1f7cd7c3c9f5db397041e21c95b30d332b216c030fd7152421L415-R415) [[13]](diffhunk://#diff-af9e60e89760bf1f7cd7c3c9f5db397041e21c95b30d332b216c030fd7152421L492-R492) [[14]](diffhunk://#diff-af9e60e89760bf1f7cd7c3c9f5db397041e21c95b30d332b216c030fd7152421L527-R529) [[15]](diffhunk://#diff-af9e60e89760bf1f7cd7c3c9f5db397041e21c95b30d332b216c030fd7152421L572-R572) [[16]](diffhunk://#diff-af9e60e89760bf1f7cd7c3c9f5db397041e21c95b30d332b216c030fd7152421L592-R592) [[17]](diffhunk://#diff-af9e60e89760bf1f7cd7c3c9f5db397041e21c95b30d332b216c030fd7152421L613-R614) [[18]](diffhunk://#diff-af9e60e89760bf1f7cd7c3c9f5db397041e21c95b30d332b216c030fd7152421L653-R653) [[19]](diffhunk://#diff-af9e60e89760bf1f7cd7c3c9f5db397041e21c95b30d332b216c030fd7152421L703-R703) [[20]](diffhunk://#diff-af9e60e89760bf1f7cd7c3c9f5db397041e21c95b30d332b216c030fd7152421L738-R738) [[21]](diffhunk://#diff-af9e60e89760bf1f7cd7c3c9f5db397041e21c95b30d332b216c030fd7152421L769-R772) [[22]](diffhunk://#diff-af9e60e89760bf1f7cd7c3c9f5db397041e21c95b30d332b216c030fd7152421L839-R842) [[23]](diffhunk://#diff-af9e60e89760bf1f7cd7c3c9f5db397041e21c95b30d332b216c030fd7152421L906-R910) [[24]](diffhunk://#diff-af9e60e89760bf1f7cd7c3c9f5db397041e21c95b30d332b216c030fd7152421L952-R952) [[25]](diffhunk://#diff-af9e60e89760bf1f7cd7c3c9f5db397041e21c95b30d332b216c030fd7152421L996-R996) [[26]](diffhunk://#diff-af9e60e89760bf1f7cd7c3c9f5db397041e21c95b30d332b216c030fd7152421L1007-R1007)

**Configuration updates:**

* Added a `.claude/settings.json` file to allow `npx hardhat compile` and `npx hardhat test` permissions for development tooling.