### PR TITLE
Improve sponsorship eligibility checks and error messaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ __pycache__
 # Local development
 .overmind.sock
 .dev/
-backend/.venv/

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,3 +1,4 @@
 .venv
 __pycache__/
 .generated/
+.sqlite/

--- a/backend/src/symvolia/gas_sponsorship/api.py
+++ b/backend/src/symvolia/gas_sponsorship/api.py
@@ -46,6 +46,12 @@ GAS_LIMIT_FIELDS = (
     "paymasterPostOpGasLimit",
 )
 
+# Fallback weight for the read-only eligibility preview when a caller's
+# userOperation carries no gas-limit fields yet (e.g. it wasn't fully prepared).
+# A forum submit is well under this, so it's a conservative "typical action"
+# stand-in that keeps the preview answerable without a real estimate.
+NOMINAL_ELIGIBILITY_GAS = 500_000.0
+
 DEFAULT_REGISTRY_SIGNATURES_BY_MODE = {
     "mocked": ["register(string)"],
     "production": [
@@ -430,9 +436,28 @@ def _idempotency_key(user_operation: dict[str, Any]) -> str:
     return hashlib.sha256(f"{sender}|{nonce}|{call_data}".encode()).hexdigest()
 
 
+def _format_usage(usage: float | None, capacity: float | None) -> str | None:
+    """Render bucket usage as ``%<pct> (<usage>/<capacity>)`` for logs."""
+    if usage is None or capacity is None:
+        return None
+    pct = round(usage / capacity * 100) if capacity > 0 else 0
+    return f"%{pct} ({usage:.0f}/{capacity:.0f})"
+
+
+@dataclass
+class MeteringOutcome:
+    """Result of metering an approved action, with detail for decision logs."""
+
+    approved: bool
+    reason: str
+    user_id: str | None = None
+    usage_gas: float | None = None
+    capacity_gas: float | None = None
+
+
 async def _apply_rate_limit(
     user_operation: dict[str, Any], action: MeteredAction, reason: str
-) -> tuple[bool, str]:
+) -> MeteringOutcome:
     """Meter an approved action by its gas cost; returns the final decision.
 
     Both failure paths below return without calling ``try_consume``, so a
@@ -441,15 +466,19 @@ async def _apply_rate_limit(
     """
     limiter = _get_rate_limiter()
     if limiter is None:
-        return True, reason
+        return MeteringOutcome(True, reason)
 
     weight = _gas_weight(user_operation)
     if weight is None:
-        return False, f"{reason}: userOperation is missing gas-limit fields"
+        return MeteringOutcome(
+            False, f"{reason}: userOperation is missing gas-limit fields"
+        )
 
     user_id = await _resolve_user_id(action)
     if user_id is None:
-        return False, f"{reason}: could not resolve zkPassport id for metering"
+        return MeteringOutcome(
+            False, f"{reason}: could not resolve zkPassport id for metering"
+        )
 
     decision = await asyncio.to_thread(
         limiter.try_consume,
@@ -458,12 +487,21 @@ async def _apply_rate_limit(
         idempotency_key=_idempotency_key(user_operation),
     )
     if not decision.allowed:
-        return False, f"{reason}: gas budget exceeded (gas={weight:.0f})"
-    return (
+        return MeteringOutcome(
+            False,
+            f"{reason}: gas budget exceeded (gas={weight:.0f})",
+            user_id=user_id,
+            usage_gas=decision.usage_after,
+            capacity_gas=decision.capacity,
+        )
+    return MeteringOutcome(
         True,
         f"{reason}: metered gas={weight:.0f} "
         f"usage={decision.usage_after:.0f}/{decision.capacity:.0f}"
         + (" (replayed)" if decision.replayed else ""),
+        user_id=user_id,
+        usage_gas=decision.usage_after,
+        capacity_gas=decision.capacity,
     )
 
 
@@ -482,8 +520,179 @@ class GasSponsorshipDecision(BaseModel):
     approved: bool
 
 
+class GasSponsorshipEligibilityRequest(BaseModel):
+    """Preview payload: the smart-wallet userOperation the client just prepared.
+
+    The frontend prepares this via Alchemy's bundler (``prepareUserOperation``),
+    so its gas-limit fields come from the same estimator the sponsorship webhook
+    will meter against at submit time.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    userOperation: dict[str, Any] = Field(default_factory=dict)
+    userId: str | None = None
+    """The caller's zkPassport id (bytes32 hex), supplied by the frontend.
+
+    Required in practice: the preview meters against it directly. The endpoint
+    never resolves identity server-side, so it can't be coerced into a registry
+    RPC. It is only trusted for this read-only *peek* — the webhook re-resolves
+    the id authoritatively before any budget is consumed, so a spoofed value
+    cannot overspend another human's allowance.
+    """
+
+
+def _normalize_client_user_id(value: str | None) -> str | None:
+    """Shape-check a client-supplied zkPassport id so it can key a bucket.
+
+    Returns the ``0x``-prefixed, lowercase, 32-byte hex id, or ``None`` when the
+    value is absent or malformed (the eligibility preview then reports an error
+    rather than resolving server-side). Metering ids produced on the backend are
+    ``"0x" + <64 hex>`` (see ``identity``), so a valid value maps to the same
+    bucket the webhook will charge.
+    """
+    if not value:
+        return None
+    text = value.strip().lower()
+    if not text.startswith("0x") or len(text) != 66:
+        return None
+    try:
+        int(text, 16)
+    except ValueError:
+        return None
+    return text
+
+
+class GasSponsorshipEligibility(BaseModel):
+    """Read-only sponsorship outlook for a prepared userOperation.
+
+    ``status`` is one of:
+
+    * ``sponsored`` — the action qualifies and the human is within budget.
+    * ``rate_limited`` — the action qualifies but the human's gas budget is
+      currently exhausted (a clean "take a break", not an error).
+    * ``ineligible`` — the action is not sponsorable (unknown selector/target,
+      sponsorship disabled, etc.).
+    * ``error`` — eligibility could not be determined (e.g. identity metering
+      lookup failed); the caller should retry or fall back to self-funding.
+    """
+
+    status: str
+    detail: str | None = None
+    usage_gas: float | None = None
+    capacity_gas: float | None = None
+    retry_after_seconds: float | None = None
+
+
+async def _evaluate_eligibility(
+    request: "GasSponsorshipEligibilityRequest",
+    user_operation: dict[str, Any],
+) -> tuple["GasSponsorshipEligibility", str | None]:
+    """Compute the eligibility preview verdict without consuming budget.
+
+    Returns the verdict plus the metering ``user_id`` used (or ``None`` when no
+    metering was performed) so the route can log it without exposing the id in
+    the response body.
+    """
+    approved, reason, action = _sponsorship_decision(user_operation)
+    if not approved or action is None:
+        return GasSponsorshipEligibility(status="ineligible", detail=reason), None
+
+    limiter = _get_rate_limiter()
+    if limiter is None:
+        # Metering disabled: any sponsorable action is unconditionally in. Still
+        # surface the client-supplied id (when present) for log correlation.
+        return (
+            GasSponsorshipEligibility(status="sponsored", detail=reason),
+            _normalize_client_user_id(request.userId),
+        )
+
+    weight = _gas_weight(user_operation)
+    if weight is None:
+        weight = NOMINAL_ELIGIBILITY_GAS
+
+    # This preview is only ever called by the frontend, which already holds
+    # the caller's zkPassport id. Require it and meter against it directly:
+    # the endpoint never resolves identity server-side, so an
+    # unauthenticated caller can't force a registry RPC (a cost/DoS abuse
+    # vector). The webhook remains the authoritative, RPC-backed metering
+    # path at submit time.
+    user_id = _normalize_client_user_id(request.userId)
+    if user_id is None:
+        return (
+            GasSponsorshipEligibility(
+                status="error",
+                detail=f"{reason}: a valid userId is required for a metering preview",
+            ),
+            None,
+        )
+
+    decision = await asyncio.to_thread(limiter.peek, user_id, weight)
+    if decision.allowed:
+        return (
+            GasSponsorshipEligibility(
+                status="sponsored",
+                detail=reason,
+                usage_gas=decision.usage_after,
+                capacity_gas=decision.capacity,
+            ),
+            user_id,
+        )
+
+    # Rejected: report how long until enough budget leaks back to fit this
+    # action, so the UI can offer a concrete "try again in ~N" hint.
+    over = decision.usage_after + weight - decision.capacity
+    retry_after = over / limiter.leak_per_second if limiter.leak_per_second > 0 else None
+    return (
+        GasSponsorshipEligibility(
+            status="rate_limited",
+            detail=f"{reason}: gas budget exceeded (gas={weight:.0f})",
+            usage_gas=decision.usage_after,
+            capacity_gas=decision.capacity,
+            retry_after_seconds=retry_after,
+        ),
+        user_id,
+    )
+
+
 def create_api(app: FastAPI) -> None:
     """Register gas sponsorship routes on *app*."""
+
+    @app.post("/alchemy/gas-policy/eligibility")
+    async def check_gas_sponsorship_eligibility(
+        request: GasSponsorshipEligibilityRequest,
+    ) -> GasSponsorshipEligibility:
+        """Preview whether a prepared userOperation would be sponsored.
+
+        Mirrors the webhook's decision + metering logic but *peeks* the
+        rate-limit bucket instead of consuming it, so the confirmation dialog can
+        distinguish a clean rate-limit decline from a genuine error before the
+        user submits. It never charges budget: the authoritative decision remains
+        the webhook (`/alchemy/gas-policy/inspect`) at submit time.
+        """
+        user_operation = request.userOperation
+        logger.info(
+            "Gas sponsorship eligibility request: sender=%s user_operation_keys=%s "
+            "call_data=%s user_id_present=%s",
+            user_operation.get("sender"),
+            sorted(user_operation.keys()),
+            _summarize_hex(user_operation.get("callData")),
+            request.userId is not None,
+        )
+
+        result, metering_user_id = await _evaluate_eligibility(
+            request, user_operation
+        )
+        logger.info(
+            "Gas sponsorship eligibility decision: status=%s detail=%s sender=%s "
+            "user_id=%s usage=%s",
+            result.status,
+            result.detail,
+            user_operation.get("sender"),
+            metering_user_id,
+            _format_usage(result.usage_gas, result.capacity_gas),
+        )
+        return result
 
     @app.post("/alchemy/gas-policy/inspect")
     async def inspect_alchemy_gas_policy(
@@ -515,12 +724,19 @@ def create_api(app: FastAPI) -> None:
             ),
         )
         approved, reason, action = _sponsorship_decision(user_operation)
+        outcome: MeteringOutcome | None = None
         if approved and action is not None:
-            approved, reason = await _apply_rate_limit(user_operation, action, reason)
+            outcome = await _apply_rate_limit(user_operation, action, reason)
+            approved, reason = outcome.approved, outcome.reason
         logger.info(
-            "Alchemy gas policy decision: approved=%s reason=%s sender=%s",
+            "Alchemy gas policy decision: approved=%s reason=%s sender=%s "
+            "user_id=%s usage=%s",
             approved,
             reason,
             user_operation.get("sender"),
+            outcome.user_id if outcome else None,
+            _format_usage(outcome.usage_gas, outcome.capacity_gas)
+            if outcome
+            else None,
         )
         return GasSponsorshipDecision(approved=approved)

--- a/backend/src/symvolia/gas_sponsorship/rate_limiter.py
+++ b/backend/src/symvolia/gas_sponsorship/rate_limiter.py
@@ -189,3 +189,43 @@ class LeakyBucketRateLimiter:
                 )
             finally:
                 connection.close()
+
+    def peek(
+        self,
+        user_id: str,
+        weight: float,
+        *,
+        now: float | None = None,
+    ) -> RateLimitDecision:
+        """Return the decision for *weight* **without** charging the bucket.
+
+        Mirrors :meth:`try_consume`'s projection math but performs no writes, so
+        it can back a read-only eligibility preview without consuming a human's
+        budget. ``usage_after`` reports the *current* decayed level (the weight
+        is not added on a rejection, and only hypothetically added when it would
+        be allowed), and ``replayed`` is always ``False``.
+        """
+        if now is None:
+            now = time.time()
+        weight = float(weight)
+
+        with self._lock:
+            connection = self._connect()
+            try:
+                row = connection.execute(
+                    "SELECT usage, updated_at FROM sponsorship_bucket"
+                    " WHERE user_id = ?",
+                    (user_id,),
+                ).fetchone()
+                usage, updated_at = row if row is not None else (0.0, now)
+                decayed = max(0.0, usage - self.leak_per_second * (now - updated_at))
+                projected = decayed + weight
+                allowed = projected <= self.capacity
+                return RateLimitDecision(
+                    allowed=allowed,
+                    usage_after=projected if allowed else decayed,
+                    capacity=self.capacity,
+                    replayed=False,
+                )
+            finally:
+                connection.close()

--- a/backend/tests/test_gas_sponsorship_api.py
+++ b/backend/tests/test_gas_sponsorship_api.py
@@ -468,5 +468,222 @@ class GasSponsorshipMeteringTests(unittest.TestCase):
         self.assertEqual(response.json(), {"approved": False})
 
 
+class GasSponsorshipEligibilityTests(unittest.TestCase):
+    def setUp(self) -> None:
+        app = FastAPI()
+        create_api(app)
+        self.client = TestClient(app)
+        directory = tempfile.mkdtemp()
+        self.db_path = os.path.join(directory, "sponsorship.db")
+        self.sender = "0x0000000000000000000000000000000000000abc"
+        # The webhook meters this sender against its reproduced mock id; the
+        # preview must pass the same id so both hit the same bucket.
+        self.user_id = identity.mock_registration_user_id(self.sender)
+
+    def _payload(self, call_data: str, nonce: str, *, gas: int = 200_000) -> dict:
+        call_gas = gas // 2
+        verification_gas = gas // 4
+        pre_verification_gas = gas - call_gas - verification_gas
+        return {
+            "userOperation": {
+                "sender": self.sender,
+                "nonce": nonce,
+                "callData": call_data,
+                "callGasLimit": hex(call_gas),
+                "verificationGasLimit": hex(verification_gas),
+                "preVerificationGas": hex(pre_verification_gas),
+            },
+        }
+
+    def _eligibility_payload(
+        self,
+        call_data: str,
+        nonce: str,
+        *,
+        gas: int = 200_000,
+        user_id: str | None = None,
+    ) -> dict:
+        payload = self._payload(call_data, nonce, gas=gas)
+        payload["userId"] = self.user_id if user_id is None else user_id
+        return payload
+
+    def _mocked_register_call_data(self) -> str:
+        return _execute_call_data(
+            REGISTRY_ADDRESS,
+            _selector("register(string)") + encode(["string"], ["USA"]),
+        )
+
+    def test_eligibility_reports_sponsored_without_consuming(self) -> None:
+        call_data = self._mocked_register_call_data()
+        env = {
+            "ALCHEMY_GAS_SPONSORSHIP_INSPECT_APPROVE": "true",
+            "REGISTRY_ADDRESS": REGISTRY_ADDRESS,
+            "REGISTRY_MODE": "mocked",
+            "GAS_SPONSORSHIP_RATE_LIMIT_DB": self.db_path,
+            "GAS_SPONSORSHIP_RATE_LIMIT_CAPACITY_GAS": "800000",
+            "GAS_SPONSORSHIP_RATE_LIMIT_LEAK_GAS_PER_DAY": "0",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            # Capacity only covers four 200000-gas actions, but peeking never
+            # consumes, so every preview stays sponsored.
+            previews = [
+                self.client.post(
+                    "/alchemy/gas-policy/eligibility",
+                    json=self._eligibility_payload(call_data, hex(nonce)),
+                ).json()
+                for nonce in range(10)
+            ]
+            # The bucket is untouched, so live metering still grants four actions.
+            approvals = [
+                self.client.post(
+                    "/alchemy/gas-policy/inspect",
+                    json=self._payload(call_data, hex(nonce)),
+                ).json()["approved"]
+                for nonce in range(100, 105)
+            ]
+
+        self.assertTrue(all(p["status"] == "sponsored" for p in previews))
+        self.assertEqual(approvals, [True, True, True, True, False])
+
+    def test_eligibility_reports_rate_limited_when_budget_exhausted(self) -> None:
+        call_data = self._mocked_register_call_data()
+        env = {
+            "ALCHEMY_GAS_SPONSORSHIP_INSPECT_APPROVE": "true",
+            "REGISTRY_ADDRESS": REGISTRY_ADDRESS,
+            "REGISTRY_MODE": "mocked",
+            "GAS_SPONSORSHIP_RATE_LIMIT_DB": self.db_path,
+            "GAS_SPONSORSHIP_RATE_LIMIT_CAPACITY_GAS": "300000",
+            # 1 gas/second leak keeps retry_after finite and positive.
+            "GAS_SPONSORSHIP_RATE_LIMIT_LEAK_GAS_PER_DAY": "86400",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            # Consume the whole 300000-gas bucket with a real sponsored action.
+            first = self.client.post(
+                "/alchemy/gas-policy/inspect",
+                json=self._payload(call_data, "0x1", gas=300_000),
+            )
+            self.assertTrue(first.json()["approved"])
+            # A preview for another 300000-gas action no longer fits.
+            preview = self.client.post(
+                "/alchemy/gas-policy/eligibility",
+                json=self._eligibility_payload(call_data, "0x2", gas=300_000),
+            ).json()
+
+        self.assertEqual(preview["status"], "rate_limited")
+        self.assertIsNotNone(preview["retry_after_seconds"])
+        self.assertGreater(preview["retry_after_seconds"], 0)
+
+    def test_eligibility_reports_ineligible_for_unsponsored_target(self) -> None:
+        # A call to a contract that is neither the registry nor a forum.
+        call_data = _execute_call_data(
+            "0x00000000000000000000000000000000000000cc",
+            _selector("register(string)") + encode(["string"], ["USA"]),
+        )
+        env = {
+            "ALCHEMY_GAS_SPONSORSHIP_INSPECT_APPROVE": "true",
+            "REGISTRY_ADDRESS": REGISTRY_ADDRESS,
+            "REGISTRY_MODE": "mocked",
+            "GAS_SPONSORSHIP_RATE_LIMIT_DB": self.db_path,
+            "GAS_SPONSORSHIP_RATE_LIMIT_CAPACITY_GAS": "800000",
+            "GAS_SPONSORSHIP_RATE_LIMIT_LEAK_GAS_PER_DAY": "0",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            preview = self.client.post(
+                "/alchemy/gas-policy/eligibility",
+                json=self._payload(call_data, "0x1"),
+            ).json()
+
+        self.assertEqual(preview["status"], "ineligible")
+
+    def test_eligibility_requires_user_id(self) -> None:
+        # Without a client-supplied userId the endpoint must not resolve identity
+        # server-side (which would trigger a registry RPC); it errors instead.
+        call_data = _execute_call_data(
+            FORUM_ADDRESS,
+            _add_statement_call_data("hello", 1),
+        )
+        env = {
+            "ALCHEMY_GAS_SPONSORSHIP_INSPECT_APPROVE": "true",
+            "REGISTRY_ADDRESS": REGISTRY_ADDRESS,
+            "FORUM_CONTRACT_ADDRESSES": FORUM_ADDRESS,
+            "REGISTRY_MODE": "production",
+            "GAS_SPONSORSHIP_RATE_LIMIT_DB": self.db_path,
+            "GAS_SPONSORSHIP_RPC_URL": "http://rpc.invalid",
+        }
+        resolver = AsyncMock(return_value="0x" + "44" * 32)
+        with patch.dict(os.environ, env, clear=True), patch.object(
+            identity, "resolve_forum_user_id", resolver
+        ):
+            preview = self.client.post(
+                "/alchemy/gas-policy/eligibility",
+                json=self._payload(call_data, "0x1"),
+            ).json()
+
+        self.assertEqual(preview["status"], "error")
+        resolver.assert_not_awaited()
+
+    def test_eligibility_uses_client_user_id_hint_without_rpc(self) -> None:
+        # A forum action would normally resolve the id via RPC; a valid client
+        # hint lets the preview meter directly and skip that call entirely.
+        call_data = _execute_call_data(
+            FORUM_ADDRESS,
+            _add_statement_call_data("hello", 1),
+        )
+        env = {
+            "ALCHEMY_GAS_SPONSORSHIP_INSPECT_APPROVE": "true",
+            "REGISTRY_ADDRESS": REGISTRY_ADDRESS,
+            "FORUM_CONTRACT_ADDRESSES": FORUM_ADDRESS,
+            "REGISTRY_MODE": "production",
+            "GAS_SPONSORSHIP_RATE_LIMIT_DB": self.db_path,
+            "GAS_SPONSORSHIP_RATE_LIMIT_CAPACITY_GAS": "800000",
+            "GAS_SPONSORSHIP_RATE_LIMIT_LEAK_GAS_PER_DAY": "0",
+            "GAS_SPONSORSHIP_RPC_URL": "http://rpc.invalid",
+        }
+        resolver = AsyncMock(return_value=None)
+        payload = self._payload(call_data, "0x1")
+        payload["userId"] = "0x" + "22" * 32
+        with patch.dict(os.environ, env, clear=True), patch.object(
+            identity, "resolve_forum_user_id", resolver
+        ):
+            preview = self.client.post(
+                "/alchemy/gas-policy/eligibility",
+                json=payload,
+            ).json()
+
+        self.assertEqual(preview["status"], "sponsored")
+        resolver.assert_not_awaited()
+
+    def test_eligibility_rejects_malformed_client_user_id(self) -> None:
+        # A malformed userId is discarded (so it can't key a junk bucket) and,
+        # with no server-side resolution, the endpoint errors without any RPC.
+        call_data = _execute_call_data(
+            FORUM_ADDRESS,
+            _add_statement_call_data("hello", 1),
+        )
+        env = {
+            "ALCHEMY_GAS_SPONSORSHIP_INSPECT_APPROVE": "true",
+            "REGISTRY_ADDRESS": REGISTRY_ADDRESS,
+            "FORUM_CONTRACT_ADDRESSES": FORUM_ADDRESS,
+            "REGISTRY_MODE": "production",
+            "GAS_SPONSORSHIP_RATE_LIMIT_DB": self.db_path,
+            "GAS_SPONSORSHIP_RATE_LIMIT_CAPACITY_GAS": "800000",
+            "GAS_SPONSORSHIP_RATE_LIMIT_LEAK_GAS_PER_DAY": "0",
+            "GAS_SPONSORSHIP_RPC_URL": "http://rpc.invalid",
+        }
+        resolver = AsyncMock(return_value="0x" + "33" * 32)
+        payload = self._payload(call_data, "0x1")
+        payload["userId"] = "not-a-bytes32"
+        with patch.dict(os.environ, env, clear=True), patch.object(
+            identity, "resolve_forum_user_id", resolver
+        ):
+            preview = self.client.post(
+                "/alchemy/gas-policy/eligibility",
+                json=payload,
+            ).json()
+
+        self.assertEqual(preview["status"], "error")
+        resolver.assert_not_awaited()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/env/profiles/base-sepolia.env
+++ b/env/profiles/base-sepolia.env
@@ -1,6 +1,9 @@
 # Local dev against committed Base Sepolia mock-registry contracts.
-# Indexer reads testnet via BASE_SEPOLIA_INDEXER_RPC_URL; frontend reads via local relay.
-INDEXER_RPC_URL=${BASE_SEPOLIA_INDEXER_RPC_URL}
+# Frontend reads testnet via the local relay (RELAY_RPC_URL).
+# Indexing is disabled here by blanking INDEXER_RPC_URL (search API still
+# serves; the indexer just won't start). To enable indexing, point it at a
+# testnet RPC, e.g. INDEXER_RPC_URL=${BASE_SEPOLIA_INDEXER_RPC_URL}.
+INDEXER_RPC_URL=""
 RELAY_RPC_URL=${BASE_SEPOLIA_RELAY_RPC_URL}
 VITE_RPC_URL=${LOCAL_BACKEND_RPC_URL}
 VITE_SEARCH_URL=${LOCAL_BACKEND_URL}
@@ -11,4 +14,12 @@ DEPLOY_NETWORK=base_sepolia
 DEPLOY_ARTIFACT_NETWORK=base_sepolia
 DEPLOYMENT_PROFILE=base-sepolia
 SEED_PROFILE=none
-REQUIRE="BASE_SEPOLIA_RPC_URL BASE_SEPOLIA_INDEXER_RPC_URL BASE_SEPOLIA_RELAY_RPC_URL"
+
+# Gas sponsorship metering (leaky-bucket, per-human gas budget). Mirrors the
+# deployed base-sepolia limits so the eligibility preview reports real usage.
+# SQLite lives under the gitignored backend/.sqlite dir (auto-created).
+GAS_SPONSORSHIP_RATE_LIMIT_DB=.sqlite/sponsorship.db
+GAS_SPONSORSHIP_RATE_LIMIT_CAPACITY_GAS=5000000
+GAS_SPONSORSHIP_RATE_LIMIT_LEAK_GAS_PER_DAY=20000000
+
+REQUIRE="BASE_SEPOLIA_RPC_URL BASE_SEPOLIA_RELAY_RPC_URL"

--- a/frontend/src/components/CommitConfirmationDialog.tsx
+++ b/frontend/src/components/CommitConfirmationDialog.tsx
@@ -48,7 +48,9 @@ const CommitConfirmationDialog = ({
 
   const networkFeeValue = isNetworkFeeLoading
     ? "Checking..."
-    : networkFeeError || networkFee?.label || "Not checked";
+    : networkFeeError
+      ? "Couldn't estimate"
+      : networkFee?.label || "Not checked";
   // Self-funded transactions charge the user's own wallet, so require an
   // explicit fee acknowledgement before confirming.
   const requiresFeeAcknowledgement = networkFee?.kind === "self-funded";
@@ -175,14 +177,21 @@ const CommitConfirmationDialog = ({
                   {networkFee.reason}
                 </Typography>
               )}
+              {networkFeeError && (
+                <Typography variant="caption" color="error">
+                  We couldn&apos;t estimate the network fee. Please try again.
+                </Typography>
+              )}
             </Stack>
           </Box>
 
           {isSponsorshipFallback && (
             <Alert severity="warning" sx={{ borderRadius: 2 }}>
-              An error occurred, so your transaction cannot be sponsored by
-              Symvolia. Click Continue to proceed with a self-funded
-              transaction, or try again later.
+              {networkFee?.warning ||
+                networkFee?.reason ||
+                "This transaction cannot be sponsored by Symvolia."}{" "}
+              Click Continue to proceed with a self-funded transaction, or try
+              again later.
             </Alert>
           )}
 

--- a/frontend/src/components/CreditActionPanel.tsx
+++ b/frontend/src/components/CreditActionPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import {
   Box,
   Button,
@@ -81,13 +81,13 @@ const CreditActionPanel: React.FC = () => {
     : false;
   const commitBusy = isUserVerified
     ? userVotes.state?.commitStatus !== undefined &&
-      userVotes.state?.commitStatus !== "idle"
+    userVotes.state?.commitStatus !== "idle"
     : false;
-  const commitChanges = isUserVerified ? userVotes.commitChanges : () => {};
+  const commitChanges = isUserVerified ? userVotes.commitChanges : () => { };
   const previewCommitChanges = isUserVerified
     ? userVotes.previewCommitChanges
     : undefined;
-  const resetChanges = isUserVerified ? userVotes.resetChanges : () => {};
+  const resetChanges = isUserVerified ? userVotes.resetChanges : () => { };
   const hasEnoughCredits = isUserVerified
     ? (userVotes.state?.hasEnoughCredits ?? true)
     : true;
@@ -116,15 +116,25 @@ const CreditActionPanel: React.FC = () => {
   const hasActionPanel = showGetVerified || showCitizenNote || showCredits;
   const pendingCount = stagedStatementCount + stagedSupportCount;
 
+  // Capture the latest preview function in a ref so the effect below runs
+  // exactly once per dialog open, instead of re-firing every time the callback
+  // identity churns (e.g. Privy handing back a fresh smart-wallet client on its
+  // own re-render cadence). Staged changes can't change while the modal is
+  // open, so a single preview is correct.
+  const previewCommitChangesRef = useRef(previewCommitChanges);
+  previewCommitChangesRef.current = previewCommitChanges;
+
   useEffect(() => {
-    if (!commitDialogOpen || !previewCommitChanges) return;
+    if (!commitDialogOpen) return;
+    const runPreview = previewCommitChangesRef.current;
+    if (!runPreview) return;
 
     let isCancelled = false;
     setCommitPreview(null);
     setCommitPreviewError(undefined);
     setCommitPreviewLoading(true);
 
-    void previewCommitChanges()
+    void runPreview()
       .then((preview) => {
         if (isCancelled) return;
         if (preview) {
@@ -135,11 +145,10 @@ const CreditActionPanel: React.FC = () => {
       })
       .catch((error: unknown) => {
         if (isCancelled) return;
-        setCommitPreviewError(
-          error instanceof Error
-            ? error.message
-            : "Unable to check the network fee.",
-        );
+        // Show a friendly message; the raw error (often serialized JSON from
+        // viem/Alchemy) is logged for debugging rather than shown to the user.
+        console.error("Failed to preview commit network fee", error);
+        setCommitPreviewError("Unable to check the network fee.");
       })
       .finally(() => {
         if (!isCancelled) setCommitPreviewLoading(false);
@@ -148,7 +157,7 @@ const CreditActionPanel: React.FC = () => {
     return () => {
       isCancelled = true;
     };
-  }, [commitDialogOpen, previewCommitChanges]);
+  }, [commitDialogOpen]);
 
   if (!address) return null;
 
@@ -278,8 +287,8 @@ const CreditActionPanel: React.FC = () => {
                           fontVariantNumeric: "tabular-nums",
                           ...(hasStagedChanges && !commitBusy
                             ? {
-                                animation: `${shimmer} 1.5s ease-in-out infinite`,
-                              }
+                              animation: `${shimmer} 1.5s ease-in-out infinite`,
+                            }
                             : {}),
                         }}
                       >

--- a/frontend/src/components/CreditActionPanel.tsx
+++ b/frontend/src/components/CreditActionPanel.tsx
@@ -81,13 +81,13 @@ const CreditActionPanel: React.FC = () => {
     : false;
   const commitBusy = isUserVerified
     ? userVotes.state?.commitStatus !== undefined &&
-    userVotes.state?.commitStatus !== "idle"
+      userVotes.state?.commitStatus !== "idle"
     : false;
-  const commitChanges = isUserVerified ? userVotes.commitChanges : () => { };
+  const commitChanges = isUserVerified ? userVotes.commitChanges : () => {};
   const previewCommitChanges = isUserVerified
     ? userVotes.previewCommitChanges
     : undefined;
-  const resetChanges = isUserVerified ? userVotes.resetChanges : () => { };
+  const resetChanges = isUserVerified ? userVotes.resetChanges : () => {};
   const hasEnoughCredits = isUserVerified
     ? (userVotes.state?.hasEnoughCredits ?? true)
     : true;
@@ -287,8 +287,8 @@ const CreditActionPanel: React.FC = () => {
                           fontVariantNumeric: "tabular-nums",
                           ...(hasStagedChanges && !commitBusy
                             ? {
-                              animation: `${shimmer} 1.5s ease-in-out infinite`,
-                            }
+                                animation: `${shimmer} 1.5s ease-in-out infinite`,
+                              }
                             : {}),
                         }}
                       >

--- a/frontend/src/components/UserProfilePill.tsx
+++ b/frontend/src/components/UserProfilePill.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import {
   Avatar,
   Box,
@@ -81,13 +81,13 @@ const UserProfilePanel: React.FC = () => {
     : false;
   const commitBusy = isUserVerified
     ? userVotes.state?.commitStatus !== undefined &&
-      userVotes.state?.commitStatus !== "idle"
+    userVotes.state?.commitStatus !== "idle"
     : false;
-  const commitChanges = isUserVerified ? userVotes.commitChanges : () => {};
+  const commitChanges = isUserVerified ? userVotes.commitChanges : () => { };
   const previewCommitChanges = isUserVerified
     ? userVotes.previewCommitChanges
     : undefined;
-  const resetChanges = isUserVerified ? userVotes.resetChanges : () => {};
+  const resetChanges = isUserVerified ? userVotes.resetChanges : () => { };
   const hasEnoughCredits = isUserVerified
     ? (userVotes.state?.hasEnoughCredits ?? true)
     : true;
@@ -108,15 +108,25 @@ const UserProfilePanel: React.FC = () => {
   const [commitPreviewError, setCommitPreviewError] = useState<string>();
   const [resetDialogOpen, setResetDialogOpen] = useState(false);
 
+  // Capture the latest preview function in a ref so the effect below runs
+  // exactly once per dialog open, instead of re-firing every time the callback
+  // identity churns (e.g. Privy handing back a fresh smart-wallet client on its
+  // own re-render cadence). Staged changes can't change while the modal is
+  // open, so a single preview is correct.
+  const previewCommitChangesRef = useRef(previewCommitChanges);
+  previewCommitChangesRef.current = previewCommitChanges;
+
   useEffect(() => {
-    if (!commitDialogOpen || !previewCommitChanges) return;
+    if (!commitDialogOpen) return;
+    const runPreview = previewCommitChangesRef.current;
+    if (!runPreview) return;
 
     let isCancelled = false;
     setCommitPreview(null);
     setCommitPreviewError(undefined);
     setCommitPreviewLoading(true);
 
-    void previewCommitChanges()
+    void runPreview()
       .then((preview) => {
         if (isCancelled) return;
         if (preview) {
@@ -127,11 +137,10 @@ const UserProfilePanel: React.FC = () => {
       })
       .catch((error: unknown) => {
         if (isCancelled) return;
-        setCommitPreviewError(
-          error instanceof Error
-            ? error.message
-            : "Unable to check the network fee.",
-        );
+        // Show a friendly message; the raw error (often serialized JSON from
+        // viem/Alchemy) is logged for debugging rather than shown to the user.
+        console.error("Failed to preview commit network fee", error);
+        setCommitPreviewError("Unable to check the network fee.");
       })
       .finally(() => {
         if (!isCancelled) setCommitPreviewLoading(false);
@@ -140,7 +149,7 @@ const UserProfilePanel: React.FC = () => {
     return () => {
       isCancelled = true;
     };
-  }, [commitDialogOpen, previewCommitChanges]);
+  }, [commitDialogOpen]);
 
   return (
     <>
@@ -313,8 +322,8 @@ const UserProfilePanel: React.FC = () => {
                   letterSpacing: "0.05em",
                   ...(hasStagedChanges && !commitBusy
                     ? {
-                        animation: `${shimmer} 1.5s ease-in-out infinite`,
-                      }
+                      animation: `${shimmer} 1.5s ease-in-out infinite`,
+                    }
                     : {}),
                 }}
               >

--- a/frontend/src/components/UserProfilePill.tsx
+++ b/frontend/src/components/UserProfilePill.tsx
@@ -81,13 +81,13 @@ const UserProfilePanel: React.FC = () => {
     : false;
   const commitBusy = isUserVerified
     ? userVotes.state?.commitStatus !== undefined &&
-    userVotes.state?.commitStatus !== "idle"
+      userVotes.state?.commitStatus !== "idle"
     : false;
-  const commitChanges = isUserVerified ? userVotes.commitChanges : () => { };
+  const commitChanges = isUserVerified ? userVotes.commitChanges : () => {};
   const previewCommitChanges = isUserVerified
     ? userVotes.previewCommitChanges
     : undefined;
-  const resetChanges = isUserVerified ? userVotes.resetChanges : () => { };
+  const resetChanges = isUserVerified ? userVotes.resetChanges : () => {};
   const hasEnoughCredits = isUserVerified
     ? (userVotes.state?.hasEnoughCredits ?? true)
     : true;
@@ -322,8 +322,8 @@ const UserProfilePanel: React.FC = () => {
                   letterSpacing: "0.05em",
                   ...(hasStagedChanges && !commitBusy
                     ? {
-                      animation: `${shimmer} 1.5s ease-in-out infinite`,
-                    }
+                        animation: `${shimmer} 1.5s ease-in-out infinite`,
+                      }
                     : {}),
                 }}
               >

--- a/frontend/src/state/UserVotes.tsx
+++ b/frontend/src/state/UserVotes.tsx
@@ -234,7 +234,7 @@ const inverseTriangle = (
       creditMultiplier * creditMultiplier + 8 * creditMultiplier * creditCost,
     ) -
       creditMultiplier) /
-    2,
+      2,
   );
 };
 
@@ -760,9 +760,9 @@ const reducer = (
     ...newState,
     staged: newState.staged
       ? {
-        ...newState.staged,
-        credits: stagedCredits,
-      }
+          ...newState.staged,
+          credits: stagedCredits,
+        }
       : undefined,
     hasStagedChanges,
     hasEnoughCredits: stagedCredits >= 0,
@@ -951,10 +951,10 @@ export const UserVoteProvider: FC<{
   const persistKey =
     chainFingerprint && participantAddress
       ? stagedStorageKey(
-        chainFingerprint,
-        forumName,
-        participantAddress.slice(0, 10),
-      )
+          chainFingerprint,
+          forumName,
+          participantAddress.slice(0, 10),
+        )
       : undefined;
   const restoredKeyRef = useRef<string | undefined>(undefined);
   useEffect(() => {
@@ -991,10 +991,10 @@ export const UserVoteProvider: FC<{
   const pendingCommitKey =
     chainFingerprint && participantAddress
       ? pendingCommitStorageKey(
-        chainFingerprint,
-        forumName,
-        participantAddress.slice(0, 10),
-      )
+          chainFingerprint,
+          forumName,
+          participantAddress.slice(0, 10),
+        )
       : undefined;
   const restoredPendingKeyRef = useRef<string | undefined>(undefined);
   useEffect(() => {

--- a/frontend/src/state/UserVotes.tsx
+++ b/frontend/src/state/UserVotes.tsx
@@ -16,6 +16,7 @@ import { encodeFunctionData, parseEventLogs, BaseError } from "viem";
 import { FORUM_ABI, useForum } from "./Forum";
 import useBlockSync from "@/hooks/useBlockSync";
 import useLocalStorageSet from "@/hooks/useLocalStorageSet";
+import { useUserRegistration } from "@/hooks/useUserRegistration";
 import {
   type ContractWriteRequest,
   type SponsoredNetworkFeeEstimate,
@@ -233,7 +234,7 @@ const inverseTriangle = (
       creditMultiplier * creditMultiplier + 8 * creditMultiplier * creditCost,
     ) -
       creditMultiplier) /
-      2,
+    2,
   );
 };
 
@@ -759,9 +760,9 @@ const reducer = (
     ...newState,
     staged: newState.staged
       ? {
-          ...newState.staged,
-          credits: stagedCredits,
-        }
+        ...newState.staged,
+        credits: stagedCredits,
+      }
       : undefined,
     hasStagedChanges,
     hasEnoughCredits: stagedCredits >= 0,
@@ -834,6 +835,7 @@ export const UserVoteProvider: FC<{
     isLoading: isWalletLoading,
     kind: walletKind,
   } = useWalletAuth();
+  const { userId } = useUserRegistration();
   const publicClient = usePublicClient();
   const {
     forumContractAddress,
@@ -949,10 +951,10 @@ export const UserVoteProvider: FC<{
   const persistKey =
     chainFingerprint && participantAddress
       ? stagedStorageKey(
-          chainFingerprint,
-          forumName,
-          participantAddress.slice(0, 10),
-        )
+        chainFingerprint,
+        forumName,
+        participantAddress.slice(0, 10),
+      )
       : undefined;
   const restoredKeyRef = useRef<string | undefined>(undefined);
   useEffect(() => {
@@ -989,10 +991,10 @@ export const UserVoteProvider: FC<{
   const pendingCommitKey =
     chainFingerprint && participantAddress
       ? pendingCommitStorageKey(
-          chainFingerprint,
-          forumName,
-          participantAddress.slice(0, 10),
-        )
+        chainFingerprint,
+        forumName,
+        participantAddress.slice(0, 10),
+      )
       : undefined;
   const restoredPendingKeyRef = useRef<string | undefined>(undefined);
   useEffect(() => {
@@ -1169,9 +1171,9 @@ export const UserVoteProvider: FC<{
     return {
       statementCount: state.staged.stagedStatements.length,
       supportAdjustmentCount: state.staged.supportAdjustments.size,
-      networkFee: await previewNetworkFee(request),
+      networkFee: await previewNetworkFee(request, { userId }),
     };
-  }, [buildCommitRequest, previewNetworkFee, state.staged]);
+  }, [buildCommitRequest, previewNetworkFee, state.staged, userId]);
 
   const commitChanges = useCallback(
     async (options?: CommitChangesOptions) => {

--- a/frontend/src/wallet/sponsorshipEligibility.ts
+++ b/frontend/src/wallet/sponsorshipEligibility.ts
@@ -1,0 +1,108 @@
+import { backendSearchUrl } from "@/hooks/useSearchEngineMode";
+import type { SponsoredNetworkFeeEstimate } from "./types";
+
+/**
+ * Sponsorship outlook for a prepared userOperation, mirrored from the backend
+ * `/alchemy/gas-policy/eligibility` endpoint. It lets the fee preview tell a
+ * clean rate-limit decline apart from a genuine error before the user submits.
+ */
+export type SponsorshipEligibilityStatus =
+  | "sponsored"
+  | "rate_limited"
+  | "ineligible"
+  | "error";
+
+export type SponsorshipEligibility = {
+  status: SponsorshipEligibilityStatus;
+  detail?: string;
+  retryAfterSeconds?: number;
+};
+
+const RATE_LIMITED_WARNING =
+  "Symvolia has hit its sponsorship limit for now.";
+
+/**
+ * viem prepares user operations with `bigint` gas/nonce fields, which are not
+ * JSON-serialisable. Convert them to decimal strings; the backend accepts hex,
+ * decimal, or integer numeric fields.
+ */
+const serializeUserOperation = (
+  userOperation: Record<string, unknown>,
+): Record<string, unknown> => {
+  const serialized: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(userOperation)) {
+    serialized[key] = typeof value === "bigint" ? value.toString() : value;
+  }
+  return serialized;
+};
+
+/**
+ * Ask the backend whether a prepared userOperation would be sponsored. Returns
+ * `undefined` when no backend is configured, no `userId` is available, or the
+ * request fails, so callers degrade to their client-side heuristic. The
+ * `userId` (the caller's zkPassport id) is required: the endpoint meters
+ * against it directly and never resolves identity server-side, so we skip the
+ * call rather than send one it would reject. It is only used for this
+ * read-only preview and never consumes budget.
+ */
+export const fetchSponsorshipEligibility = async (
+  userOperation: Record<string, unknown>,
+  userId?: string | null,
+): Promise<SponsorshipEligibility | undefined> => {
+  if (!backendSearchUrl || !userId) return undefined;
+  try {
+    const response = await fetch(
+      `${backendSearchUrl}/alchemy/gas-policy/eligibility`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          userOperation: serializeUserOperation(userOperation),
+          userId,
+        }),
+      },
+    );
+    if (!response.ok) return undefined;
+    const data = (await response.json()) as {
+      status?: string;
+      detail?: string | null;
+      retry_after_seconds?: number | null;
+    };
+    if (!data.status) return undefined;
+    return {
+      status: data.status as SponsorshipEligibilityStatus,
+      detail: data.detail ?? undefined,
+      retryAfterSeconds:
+        typeof data.retry_after_seconds === "number"
+          ? data.retry_after_seconds
+          : undefined,
+    };
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * Map a sponsorship-eligibility result onto the fee estimate's `reason`/
+ * `warning` fields. Returns `undefined` for the `sponsored` status, where the
+ * meter says we are within budget so the decline came from Alchemy's own policy
+ * (or a transient error) — the caller then keeps its own fallback message.
+ */
+export const eligibilityFeeExtra = (
+  eligibility: SponsorshipEligibility,
+): Pick<SponsoredNetworkFeeEstimate, "reason" | "warning"> | undefined => {
+  switch (eligibility.status) {
+    case "rate_limited":
+      return { warning: RATE_LIMITED_WARNING };
+    case "ineligible":
+      return {
+        reason:
+          "This action isn't eligible for gas sponsorship, so it will be self-funded.",
+      };
+    case "error":
+      return { warning: "Sponsorship couldn't be confirmed right now." };
+    case "sponsored":
+    default:
+      return undefined;
+  }
+};

--- a/frontend/src/wallet/sponsorshipEligibility.ts
+++ b/frontend/src/wallet/sponsorshipEligibility.ts
@@ -18,8 +18,7 @@ export type SponsorshipEligibility = {
   retryAfterSeconds?: number;
 };
 
-const RATE_LIMITED_WARNING =
-  "Symvolia has hit its sponsorship limit for now.";
+const RATE_LIMITED_WARNING = "Symvolia has hit its sponsorship limit for now.";
 
 /**
  * viem prepares user operations with `bigint` gas/nonce fields, which are not

--- a/frontend/src/wallet/useContractWrite.ts
+++ b/frontend/src/wallet/useContractWrite.ts
@@ -9,17 +9,18 @@ import {
   SELF_FUNDED_NETWORK_FEE_ESTIMATE,
   SPONSORED_NETWORK_FEE_ESTIMATE,
   SPONSORSHIP_UNAVAILABLE_NETWORK_FEE_ESTIMATE,
-  classifySponsorshipWarning,
   contractWriteData,
   formatUsdFee,
   isPaymasterError,
-  isSponsoredUserOperation,
   selfFundedLabel,
-  smartWalletCalls,
   sponsoredTransactionUiOptions,
   unsponsoredUserOperationRequest,
   userOperationFeeWei,
 } from "./sponsoredWrite";
+import {
+  eligibilityFeeExtra,
+  fetchSponsorshipEligibility,
+} from "./sponsorshipEligibility";
 import type {
   ContractWriteRequest,
   SponsoredNetworkFeeEstimate,
@@ -41,6 +42,7 @@ export const useContractWrite = () => {
   const previewNetworkFee = useCallback(
     async (
       request: ContractWriteRequest,
+      options?: { userId?: string | null },
     ): Promise<SponsoredNetworkFeeEstimate> => {
       if (!isSponsored) {
         return SELF_FUNDED_NETWORK_FEE_ESTIMATE;
@@ -62,65 +64,49 @@ export const useContractWrite = () => {
         };
       }
 
-      // Builds a self-funded estimate through the smart wallet (identity stays
-      // the same). Prices an unsponsored user operation when one isn't already
-      // available, degrading to a label without a dollar figure if it cannot be
-      // prepared or priced.
-      const buildSelfFundedEstimate = async (
-        userOperation: Record<string, unknown> | undefined,
-        extra: Pick<SponsoredNetworkFeeEstimate, "reason" | "warning">,
-      ): Promise<SponsoredNetworkFeeEstimate> => {
-        let operation = userOperation;
-        if (!operation) {
-          try {
-            operation = (await smartWalletClient.prepareUserOperation(
-              unsponsoredUserOperationRequest(request) as unknown as Parameters<
-                typeof smartWalletClient.prepareUserOperation
-              >[0],
-            )) as Record<string, unknown>;
-          } catch {
-            operation = undefined;
-          }
-        }
-
-        const feeWei = operation ? userOperationFeeWei(operation) : undefined;
-        const ethUsdPrice = publicClient
-          ? await fetchEthUsdPrice(publicClient)
-          : undefined;
-        const feeUsd =
-          feeWei !== undefined && ethUsdPrice !== undefined
-            ? formatUsdFee(feeWei, ethUsdPrice)
-            : "";
-
-        return {
-          kind: "self-funded",
-          label: selfFundedLabel(feeUsd),
-          ...extra,
-        };
-      };
-
+      // Prepare and price an *unsponsored* user operation. This deliberately
+      // never requests paymaster sponsorship, so previewing the fee invokes no
+      // Alchemy paymaster webhook and consumes no sponsorship budget — only a
+      // real submit hits the paymaster.
+      let unsponsoredOp: Record<string, unknown> | undefined;
       try {
-        const userOperation = (await smartWalletClient.prepareUserOperation({
-          calls: smartWalletCalls(request),
-        })) as Record<string, unknown>;
-
-        if (isSponsoredUserOperation(userOperation)) {
-          return SPONSORED_NETWORK_FEE_ESTIMATE;
-        }
-
-        // Prepared successfully but the paymaster declined to sponsor: the
-        // smart wallet will pay, so price the operation we already have.
-        return await buildSelfFundedEstimate(userOperation, {
-          reason:
-            "The paymaster did not sponsor this operation. The app will keep using your smart wallet so your participant identity stays the same.",
-        });
-      } catch (error) {
-        // The paymaster errored (e.g. policy limits exhausted). Fall back to a
-        // self-funded flow and surface the reason as a warning.
-        return await buildSelfFundedEstimate(undefined, {
-          warning: classifySponsorshipWarning(error),
-        });
+        unsponsoredOp = (await smartWalletClient.prepareUserOperation(
+          unsponsoredUserOperationRequest(request) as unknown as Parameters<
+            typeof smartWalletClient.prepareUserOperation
+          >[0],
+        )) as Record<string, unknown>;
+      } catch {
+        unsponsoredOp = undefined;
       }
+
+      const feeWei = unsponsoredOp
+        ? userOperationFeeWei(unsponsoredOp)
+        : undefined;
+      const ethUsdPrice = publicClient
+        ? await fetchEthUsdPrice(publicClient)
+        : undefined;
+      const feeUsd =
+        feeWei !== undefined && ethUsdPrice !== undefined
+          ? formatUsdFee(feeWei, ethUsdPrice)
+          : "";
+
+      // Ask our own meter (never the paymaster) whether this op would be
+      // sponsored. When it can't answer (no backend, no userId, or a transient
+      // error), optimistically assume sponsorship: the real submit will hit the
+      // paymaster and gracefully fall back to self-funded if it is declined.
+      const eligibility = unsponsoredOp
+        ? await fetchSponsorshipEligibility(unsponsoredOp, options?.userId)
+        : undefined;
+
+      if (!eligibility || eligibility.status === "sponsored") {
+        return SPONSORED_NETWORK_FEE_ESTIMATE;
+      }
+
+      return {
+        kind: "self-funded",
+        label: selfFundedLabel(feeUsd),
+        ...(eligibilityFeeExtra(eligibility) ?? {}),
+      };
     },
     [isSponsored, getClientForChain, publicClient],
   );

--- a/scripts/local-backend.sh
+++ b/scripts/local-backend.sh
@@ -13,8 +13,7 @@
 set -euo pipefail
 
 if [ -z "${INDEXER_RPC_URL:-}" ]; then
-  echo "❌ INDEXER_RPC_URL must be set to an HTTP JSON-RPC endpoint."
-  exit 1
+  echo "ℹ️  INDEXER_RPC_URL is empty — indexing disabled (search API still served)."
 fi
 
 if [ -z "${MEILI_URL:-}" ]; then
@@ -54,7 +53,9 @@ wait_for_meili() {
   done
 }
 
-wait_for_rpc
+if [ -n "${INDEXER_RPC_URL:-}" ]; then
+  wait_for_rpc
+fi
 wait_for_meili
 
 # Wait for generated deployment artifacts.


### PR DESCRIPTION
This pull request introduces a new read-only eligibility preview endpoint for gas sponsorship, allowing the frontend to check if a user operation would be sponsored without consuming the user's gas budget. It also refactors the internal rate limiting logic to support this preview, improves logging, and adds comprehensive tests for the new functionality.

**New eligibility preview endpoint and logic:**

* Added a `/alchemy/gas-policy/eligibility` POST endpoint to the API, which allows clients to preview whether a prepared `userOperation` would be sponsored, rate-limited, ineligible, or if an error occurred, without consuming the user's gas budget. This is implemented via a new `GasSponsorshipEligibilityRequest` and `GasSponsorshipEligibility` model, and the `_evaluate_eligibility` function.
* Introduced a `peek` method to the rate limiter (`RateLimiter.peek`) to check if a user operation would be allowed without updating or charging the rate limit bucket.
* Added a fallback nominal gas value (`NOMINAL_ELIGIBILITY_GAS`) for eligibility previews when the user operation lacks gas-limit fields.

**Refactoring and improved logging:**

* Refactored the internal rate limiting logic: `_apply_rate_limit` now returns a `MeteringOutcome` dataclass with detailed metering information, which is also used to improve logging for both the preview and webhook endpoints. [[1]](diffhunk://#diff-2e51c46fe4dfc8b7789b8689f0143bb5efe3eec324d3bfa40bf4cf94c3723ccaR439-R460) [[2]](diffhunk://#diff-2e51c46fe4dfc8b7789b8689f0143bb5efe3eec324d3bfa40bf4cf94c3723ccaL444-R481) [[3]](diffhunk://#diff-2e51c46fe4dfc8b7789b8689f0143bb5efe3eec324d3bfa40bf4cf94c3723ccaL461-R504) [[4]](diffhunk://#diff-2e51c46fe4dfc8b7789b8689f0143bb5efe3eec324d3bfa40bf4cf94c3723ccaR727-R740)
* Improved log output to include user ID and usage/capacity information for both eligibility previews and actual sponsorship decisions.

**Testing:**

* Added a comprehensive test suite for the new eligibility endpoint, covering all major cases: sponsored, rate-limited, ineligible, missing/malformed user ID, and correct bucket usage.

**Other changes:**

* Updated `.gitignore` to exclude `.sqlite/` files.
* Updated the `env/profiles/base-sepolia.env` to clarify indexer and relay configuration for local development.