### PR TITLE
Use boring avatars marble avatar

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
-        "@metamask/jazzicon": "^2.0.0",
         "@mui/icons-material": "^7.3.1",
         "@mui/material": "^7.3.1",
         "@mui/x-data-grid": "^8.10.1",
@@ -20,6 +19,7 @@
         "@privy-io/wagmi": "^4.0.10",
         "@tanstack/react-query": "^5.87.4",
         "@zkpassport/sdk": "^0.12.4",
+        "boring-avatars": "^2.0.4",
         "buffer": "^6.0.3",
         "esbuild": "^0.27.3",
         "ethers": "^6.15.0",
@@ -2000,16 +2000,6 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/@metamask/jazzicon": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@metamask/jazzicon/-/jazzicon-2.0.0.tgz",
-      "integrity": "sha512-7M+WSZWKcQAo0LEhErKf1z+D3YX0tEDAcGvcKbDyvDg34uvgeKR00mFNIYwAhdAS9t8YXxhxZgsrRBBg6X8UQg==",
-      "license": "ISC",
-      "dependencies": {
-        "color": "^0.11.3",
-        "mersenne-twister": "^1.1.0"
       }
     },
     "node_modules/@metamask/json-rpc-engine": {
@@ -9687,6 +9677,16 @@
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.2.tgz",
       "integrity": "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="
     },
+    "node_modules/boring-avatars": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/boring-avatars/-/boring-avatars-2.0.4.tgz",
+      "integrity": "sha512-xhZO/w/6aFmRfkaWohcl2NfyIy87gK5SBbys8kctZeTGF1Apjpv/10pfUuv+YEfVPkESU/h2Y6tt/Dwp+bIZPw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
     "node_modules/borsh": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.7.0.tgz",
@@ -10149,15 +10149,6 @@
         "wrap-ansi": "^6.2.0"
       }
     },
-    "node_modules/clone": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -10165,41 +10156,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/color": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
-      "integrity": "sha512-Ajpjd8asqZ6EdxQeqGzU5WBhhTfJ/0cA4Wlbre7e5vXfmDSmda7Ov6jeKoru+b0vHcb1CqvuroTHp5zIWzhVMA==",
-      "license": "MIT",
-      "dependencies": {
-        "clone": "^1.0.2",
-        "color-convert": "^1.3.0",
-        "color-string": "^0.3.0"
-      }
-    },
-    "node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "license": "MIT"
-    },
-    "node_modules/color-string": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
-      "integrity": "sha512-sz29j1bmSDfoAxKIEU6zwoIZXN6BrFbAMIhfYCNyiZXBDuU/aiHlN84lp/xDzL2ubyFhLDobHIlU1X70XRrMDA==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "^1.0.0"
       }
     },
     "node_modules/colorette": {
@@ -13571,12 +13527,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/mersenne-twister": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mersenne-twister/-/mersenne-twister-1.1.0.tgz",
-      "integrity": "sha512-mUYWsMKNrm4lfygPkL3OfGzOPTR2DBlTkBNHM//F6hGp8cLThY897crAlk3/Jo17LEOOjQUrNAx6DvgO77QJkA==",
-      "license": "MIT"
     },
     "node_modules/micro-ftch": {
       "version": "0.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,7 +35,6 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
-    "@metamask/jazzicon": "^2.0.0",
     "@mui/icons-material": "^7.3.1",
     "@mui/material": "^7.3.1",
     "@mui/x-data-grid": "^8.10.1",
@@ -44,6 +43,7 @@
     "@privy-io/wagmi": "^4.0.10",
     "@tanstack/react-query": "^5.87.4",
     "@zkpassport/sdk": "^0.12.4",
+    "boring-avatars": "^2.0.4",
     "buffer": "^6.0.3",
     "esbuild": "^0.27.3",
     "ethers": "^6.15.0",

--- a/frontend/src/components/CreditActionPanel.tsx
+++ b/frontend/src/components/CreditActionPanel.tsx
@@ -165,7 +165,7 @@ const CreditActionPanel: React.FC = () => {
     return (
       <Box
         sx={{
-          borderRadius: 4,
+          borderRadius: 3,
           bgcolor: "action.hover",
           p: 2,
           mt: 1.5,
@@ -185,7 +185,7 @@ const CreditActionPanel: React.FC = () => {
         sx={{
           display: "flex",
           flexDirection: "column",
-          borderRadius: 4,
+          borderRadius: 3,
           bgcolor: "action.hover",
           p: 2,
           mt: 1.5,

--- a/frontend/src/components/UserProfilePanel.tsx
+++ b/frontend/src/components/UserProfilePanel.tsx
@@ -48,13 +48,18 @@ const UserProfilePanel: React.FC = () => {
           alignItems: "center",
           gap: 1.5,
           bgcolor: "action.hover",
-          borderRadius: 999,
+          borderRadius: 3,
           pl: 1,
           pr: 1.5,
           py: 1,
         }}
       >
-        <Skeleton variant="circular" width={36} height={36} />
+        <Skeleton
+          variant="rounded"
+          width={36}
+          height={36}
+          sx={{ borderRadius: 2 }}
+        />
         <Box sx={{ flex: 1 }}>
           <Skeleton variant="text" width="70%" height={24} />
           <Skeleton variant="text" width="50%" height={18} />
@@ -68,10 +73,7 @@ const UserProfilePanel: React.FC = () => {
     <Box
       sx={{
         bgcolor: "action.hover",
-        borderTopLeftRadius: "30px",
-        borderTopRightRadius: "30px",
-        borderBottomLeftRadius: menuOpen ? "16px" : "30px",
-        borderBottomRightRadius: menuOpen ? "16px" : "30px",
+        borderRadius: 3,
         overflow: "hidden",
         transition: (theme) =>
           theme.transitions.create("border-radius", {
@@ -94,11 +96,14 @@ const UserProfilePanel: React.FC = () => {
           cursor: "pointer",
           bgcolor: menuOpen ? "action.selected" : "transparent",
           "&:hover": { bgcolor: "action.selected" },
-          borderBottomLeftRadius: "30px",
-          borderBottomRightRadius: "30px",
+          borderBottomLeftRadius: "12px",
+          borderBottomRightRadius: "12px",
         }}
       >
-        <Avatar src={avatar ?? undefined} sx={{ width: 36, height: 36 }} />
+        <Avatar
+          src={avatar ?? undefined}
+          sx={{ width: 36, height: 36, borderRadius: 2.5 }}
+        />
 
         <Box sx={{ minWidth: 0, flex: 1, ml: 0.5, mb: 0.25 }}>
           <Typography variant="subtitle1" fontWeight={700} noWrap>

--- a/frontend/src/hooks/useUserIdentity.ts
+++ b/frontend/src/hooks/useUserIdentity.ts
@@ -1,7 +1,7 @@
 import { useCallback } from "react";
 import useLocalStorageValue from "./useLocalStorageValue";
 import { useUserRegistration } from "./useUserRegistration";
-import { jazziconDataUri } from "../util";
+import { boringAvatarDataUri } from "../util";
 
 /** Name shown for users who have not verified their identity. */
 export const ANONYMOUS_NAME = "Anonymous";
@@ -65,7 +65,7 @@ export function useUserIdentity(): UserIdentity {
 
   const displayName = isVerified ? nickname || ANONYMOUS_NAME : ANONYMOUS_NAME;
 
-  const avatar = isVerified && userId ? jazziconDataUri(userId) : null;
+  const avatar = isVerified && userId ? boringAvatarDataUri(userId) : null;
 
   return {
     userId,

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -110,6 +110,10 @@ export const theme = createTheme({
       },
     },
     MuiAvatar: {
+      defaultProps: {
+        // Square avatars with softly rounded corners (no longer circular).
+        variant: "rounded",
+      },
       styleOverrides: {
         root: ({ theme }) => ({
           width: 40,

--- a/frontend/src/types/metamask-jazzicon.d.ts
+++ b/frontend/src/types/metamask-jazzicon.d.ts
@@ -1,6 +1,0 @@
-declare module "@metamask/jazzicon" {
-  export default function jazzicon(
-    diameter: number,
-    seed: number,
-  ): HTMLDivElement;
-}

--- a/frontend/src/util.ts
+++ b/frontend/src/util.ts
@@ -60,7 +60,7 @@ export const boringAvatarDataUri = (seed: string): string => {
       size: 80,
       variant: "marble",
       square: true,
-      colors: ["#e6626f","#efae78","#f5e19c","#a2ca8e","#66af91"],
+      colors: ["#e6626f", "#efae78", "#f5e19c", "#a2ca8e", "#66af91"],
     }),
   );
   return `data:image/svg+xml,${encodeURIComponent(svg)}`;

--- a/frontend/src/util.ts
+++ b/frontend/src/util.ts
@@ -60,7 +60,7 @@ export const boringAvatarDataUri = (seed: string): string => {
       size: 80,
       variant: "marble",
       square: true,
-      colors: ["#d699cb", "#510778", "#ffb969", "#eaf27e", "#3b8c88"],
+      colors: ["#e6626f","#efae78","#f5e19c","#a2ca8e","#66af91"],
     }),
   );
   return `data:image/svg+xml,${encodeURIComponent(svg)}`;

--- a/frontend/src/util.ts
+++ b/frontend/src/util.ts
@@ -1,5 +1,6 @@
-import jazzicon from "@metamask/jazzicon";
-import { keccak256, hexToNumber, type Hex } from "viem";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import Avatar from "boring-avatars";
 
 /** Convert credit parts to display credits (rounded to nearest integer). */
 export const partsToCredits = (
@@ -44,25 +45,23 @@ export const shortenAddress = (address: string): string =>
   `${address.slice(0, 6)}…${address.slice(-4)}`;
 
 /**
- * Fold an arbitrary-length hex string into an unsigned 32-bit integer using
- * viem's `keccak256`. Every byte of the input contributes to the digest, so two
- * ids that merely share a prefix do not collide — unlike naively truncating to
- * the first few bytes. Jazzicon seeds a 32-bit PRNG, so we take the top 4 bytes
- * of the 32-byte digest as a uniform seed.
+ * Generate a deterministic Boring Avatar as an SVG data URI from an arbitrary
+ * seed string (e.g. a registry `userId`). The avatar is rendered entirely
+ * client-side — there is no network or API dependency. The same seed always
+ * yields the same avatar, and distinct seeds yield distinct avatars.
+ *
+ * A square variant is used so the surrounding UI can clip the corners to the
+ * desired radius (see the `MuiAvatar` rounded default in the theme).
  */
-const hashHexToSeed = (hex: string): number =>
-  hexToNumber(keccak256(hex as Hex).slice(0, 10) as Hex);
-
-/**
- * Generate a deterministic Jazzicon as a data URI from a hex seed
- * (e.g. an Ethereum address or a registry `userId`). All bytes of the hex
- * string are hashed into the seed, so the same input always yields the same
- * icon and distinct inputs are extremely unlikely to collide.
- */
-export const jazziconDataUri = (hexSeed: string): string => {
-  const jazziconData = jazzicon(16, hashHexToSeed(hexSeed));
-  const jazziconSvg = new XMLSerializer().serializeToString(
-    jazziconData.children[0],
+export const boringAvatarDataUri = (seed: string): string => {
+  const svg = renderToStaticMarkup(
+    createElement(Avatar, {
+      name: seed,
+      size: 80,
+      variant: "marble",
+      square: true,
+      colors: ["#d699cb", "#510778", "#ffb969", "#eaf27e", "#3b8c88"],
+    }),
   );
-  return `data:image/svg+xml,${encodeURIComponent(jazziconSvg)}`;
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
 };


### PR DESCRIPTION
This pull request updates the frontend to use Boring Avatars instead of Jazzicon for user avatars and makes related UI and dependency changes. It also standardizes avatar styling to use softly rounded square corners throughout the application.

**Avatar and Dependency Updates:**

* Replaced the `@metamask/jazzicon` dependency with `boring-avatars` in both `package.json` and `package-lock.json`, removing related dependencies such as `color`, `mersenne-twister`, and their sub-dependencies. [[1]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655L38) [[2]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655R46) [[3]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aL14) [[4]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aR22) [[5]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aL2005-L2014) [[6]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aR9680-R9689) [[7]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aL10152-L10160) [[8]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aL10170-L10204) [[9]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aL13575-L13580)
* Updated the avatar generation utility: removed Jazzicon logic and implemented a new `boringAvatarDataUri` function using the `boring-avatars` package for deterministic, client-side SVG avatars. [[1]](diffhunk://#diff-a86ab13a923476fbf115cbafba45d7fd6418192631310645a367ce0d3756010dL1-R3) [[2]](diffhunk://#diff-a86ab13a923476fbf115cbafba45d7fd6418192631310645a367ce0d3756010dL47-R66)
* Updated all usage of avatar data URIs and related hooks to use `boringAvatarDataUri` instead of `jazziconDataUri`. [[1]](diffhunk://#diff-d00576b45fd20f4bf395e04356fe4644f5d6309ee6261350afa8debe3555fce2L4-R4) [[2]](diffhunk://#diff-d00576b45fd20f4bf395e04356fe4644f5d6309ee6261350afa8debe3555fce2L68-R68)

**UI and Theming Consistency:**

* Standardized avatar and panel border radii to use softly rounded square corners (e.g., `borderRadius: 3`), and updated the default `MuiAvatar` variant to `rounded` in the theme. [[1]](diffhunk://#diff-41fee61bc7987377434f61952b9de1206e71401985ab8bac495a00d22a5678a9R113-R116) [[2]](diffhunk://#diff-6275715356f0e264f69101bb22d9dca05b2e1781e2bd3d7fde790abd3f105b80L168-R168) [[3]](diffhunk://#diff-6275715356f0e264f69101bb22d9dca05b2e1781e2bd3d7fde790abd3f105b80L188-R188) [[4]](diffhunk://#diff-cf67a382a06afe826a858200e7f0af8ac5daa336db4426871ebf9f964fe1e679L51-R62) [[5]](diffhunk://#diff-cf67a382a06afe826a858200e7f0af8ac5daa336db4426871ebf9f964fe1e679L71-R76) [[6]](diffhunk://#diff-cf67a382a06afe826a858200e7f0af8ac5daa336db4426871ebf9f964fe1e679L97-R106)
* Updated skeleton and avatar components in `UserProfilePanel` to match the new square, softly rounded avatar style. [[1]](diffhunk://#diff-cf67a382a06afe826a858200e7f0af8ac5daa336db4426871ebf9f964fe1e679L51-R62) [[2]](diffhunk://#diff-cf67a382a06afe826a858200e7f0af8ac5daa336db4426871ebf9f964fe1e679L97-R106)

These changes ensure avatars are visually consistent, modern, and generated entirely client-side without reliance on external APIs or libraries like Jazzicon.